### PR TITLE
Chirps daily mean

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ __pycache__
 */venv/*
 
 temp
+.Rproj.user

--- a/data-raw/01_chirps_daily_mean.R
+++ b/data-raw/01_chirps_daily_mean.R
@@ -1,0 +1,101 @@
+#' this code taken from `ds-adhoc-cuba`
+
+library(rgee)
+library(tidyverse)
+library(tidyrgee)
+library(targets)
+library(here)
+library(sf)
+library(cumulus)
+
+
+ee_Initialize(project = "ee-zackarno")
+
+
+cat("loading Cuba boundary from FAO GAUL\n")
+fc_gaul <- ee$FeatureCollection("FAO/GAUL/2015/level0")
+fc_aoi <- fc_gaul$filter(ee$Filter$eq("ADM0_NAME", "Cuba"))
+
+
+cat("reading and manipulate image collection\n")
+ic <- ee$ImageCollection("UCSB-CHG/CHIRPS/DAILY")
+tic <- as_tidyee(ic)
+
+
+ic_aoi <- ic$filterBounds(fc_aoi)
+
+
+yrs_unique <- tic$vrt$year |> unique()
+
+# a little trick to get 3 years at a time downloading. More than this was 
+# timing out, but less takes more time.
+
+yr_grps <- split(
+  yrs_unique,
+  ceiling(seq_along(yrs_unique) / 3)
+)
+
+# Check blob for what's already been downloaded. If already present, 
+# it will get skipped.
+pc <- cumulus::blob_containers(
+  stage= "dev"
+)$projects
+
+blobs_present <- AzureStor::list_blobs(
+  pc,
+  prefix = "ds-aa-cub-hurricanes/processed/chirps/"
+)
+
+
+yr_grps_remain <- yr_grps |> 
+  discard(
+    ~paste0("ds-aa-cub-hurricanes/processed/chirps/chirps_daily_", max(.x), ".csv") %in% blobs_present$name
+  )
+
+
+# started at 1:56 pm
+df_rainfall_adm <- yr_grps_remain %>%
+  map(
+    \(yrs){
+      cat("downloading data for year ", yrs, "\n")
+      tic_temp <- tic %>%
+        filter(
+          year %in% yrs
+        )
+
+      df_tidy <- ee_extract_tidy(
+        x = tic_temp,
+        y = fc_aoi,
+        scale = 5566,
+        stat = "mean",
+        via = "drive"
+      )
+
+      write_csv(
+        x = df_tidy,
+        file = file.path(
+          "data",
+          paste0("chirps_daily_", max(yrs), ".csv")
+        )
+      )
+      
+      cumulus::blob_write(
+        df_tidy,
+        container = "projects",
+        name = paste0("ds-aa-cub-hurricanes/processed/chirps/chirps_daily_", max(yrs), ".csv")
+        )
+    }
+  ) %>%
+  list_rbind()
+
+
+prefix_date <- format(Sys.Date(), "%Y%m%d")
+cat("write zonal sats to csv\n")
+cumulus::blob_write(
+  x = df_rainfall_adm,
+  container = "projects",
+  name = paste0("ds-aa-cub-hurricanes/processed/chirps/",prefix_date,"_chirps_daily_historical_cuba.csv"),
+  stage = "dev"
+
+)
+cat("finished")

--- a/data-raw/01_chirps_daily_mean.R
+++ b/data-raw/01_chirps_daily_mean.R
@@ -1,4 +1,8 @@
-#' this code taken from `ds-adhoc-cuba`
+#' this code taken from `ds-adhoc-cuba` repo where daily means were downloaded
+#' for a convex hull surrounding cuba. In this we do it directly on 
+#' the GAUL feature collection which is already an asset on GEE. It takes
+#' extremely long to run - this is probably due to the polygon complexity
+#' for cuba adm0.
 
 library(rgee)
 library(tidyverse)
@@ -8,8 +12,9 @@ library(here)
 library(sf)
 library(cumulus)
 
-
-ee_Initialize(project = "ee-zackarno")
+# user may need to follow `{rgee}` instructions to authenticate and initialize
+# properly if they haven't used `{rgee}` before
+ee_Initialize() 
 
 
 cat("loading Cuba boundary from FAO GAUL\n")

--- a/ds-aa-cub-hurricanes.Rproj
+++ b/ds-aa-cub-hurricanes.Rproj
@@ -1,0 +1,14 @@
+Version: 1.0
+ProjectId: bc9f5123-f9d0-4bf7-a297-15f2b81e3333
+
+RestoreWorkspace: Default
+SaveWorkspace: Default
+AlwaysSaveHistory: Default
+
+EnableCodeIndexing: Yes
+UseSpacesForTab: Yes
+NumSpacesForTab: 2
+Encoding: UTF-8
+
+RnwWeave: Sweave
+LaTeX: pdfLaTeX


### PR DESCRIPTION
`{rgee}` code to download chirps daily means for cuba polygon. This CHIRPS data was used to get a sense of CHIRPS-GEFS forecast skill in cuba around storm events. I think it can just go direct to main as it doesn't rely or alter any pre-existing code or repo structure.

I'm thinking we just merge it without needing a thorough review as it ran fine and outputs are not being used for anything critical at the moment.