### PR TITLE
feat(workflow yaml): ✨ Update forecast and observational data ingesti…

### DIFF
--- a/.github/workflows/01_run_forecast_data_ingestion.yml
+++ b/.github/workflows/01_run_forecast_data_ingestion.yml
@@ -1,8 +1,29 @@
-name: Ingest Forecast Data
+name: Forecast Monitor
 
 on:
   workflow_dispatch:
-
+      inputs:
+        TEST_EMAIL:
+          required: true
+          type: choice
+          default: "true"
+          options:
+            - "true"
+            - "false"
+        DRY_RUN:
+          required: true
+          type: choice
+          default: "false"
+          options:
+            - "true"
+            - "false"
+        FORCE_ALERT:
+          required: true
+          type: choice
+          default: "false"
+          options:
+            - "true"
+            - "false" 
 jobs:
   run-script:
     runs-on: ubuntu-latest
@@ -10,12 +31,20 @@ jobs:
       DSCI_AZ_BLOB_DEV_SAS: ${{ secrets.DSCI_AZ_BLOB_DEV_SAS }}
       DSCI_AZ_BLOB_DEV_SAS_WRITE: ${{ secrets.DSCI_AZ_BLOB_DEV_SAS_WRITE }}
       DSCI_AZ_BLOB_PROD_SAS: ${{ secrets.DSCI_AZ_BLOB_PROD_SAS }}
+      DSCI_AWS_EMAIL_HOST: ${{ secrets.DSCI_AWS_EMAIL_HOST }}
+      DSCI_AWS_EMAIL_PORT: ${{ secrets.DSCI_AWS_EMAIL_PORT }}
+      DSCI_AWS_EMAIL_PASSWORD: ${{ secrets.DSCI_AWS_EMAIL_PASSWORD }}
+      DSCI_AWS_EMAIL_USERNAME: ${{ secrets.DSCI_AWS_EMAIL_USERNAME }}
+      DSCI_AWS_EMAIL_ADDRESS: ${{ secrets.DSCI_AWS_EMAIL_ADDRESS }}
+      TEST_EMAIL: ${{ inputs.TEST_EMAIL || 'true' }}
+      DRY_RUN: ${{ inputs.DRY_RUN || 'false' }}
+      FORCE_ALERT: ${{ inputs.FORCE_ALERT || 'false' }}
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
-        ref: forecast-monitor
-
+        ref: init-email-monitoring
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -30,4 +59,4 @@ jobs:
 
     - name: Run script
       run: |
-        python pipelines/01_update_fcast_data.py
+        python pipelines/01_update_fcast_monitor.py

--- a/.github/workflows/02_run_observational_data_ingestion.yml
+++ b/.github/workflows/02_run_observational_data_ingestion.yml
@@ -1,7 +1,29 @@
-name: Ingest Observational Data
+name: Observational Monitor
 
 on:
   workflow_dispatch:
+      inputs:
+        TEST_EMAIL:
+          required: true
+          type: choice
+          default: "true"
+          options:
+            - "true"
+            - "false"
+        DRY_RUN:
+          required: true
+          type: choice
+          default: "false"
+          options:
+            - "true"
+            - "false"
+        FORCE_ALERT:
+          required: true
+          type: choice
+          default: "false"
+          options:
+            - "true"
+            - "false"
   schedule:
     - cron: '15 17 * * *' # Start at 5:15 PM UTC daily
 
@@ -12,11 +34,20 @@ jobs:
       DSCI_AZ_BLOB_DEV_SAS: ${{ secrets.DSCI_AZ_BLOB_DEV_SAS }}
       DSCI_AZ_BLOB_DEV_SAS_WRITE: ${{ secrets.DSCI_AZ_BLOB_DEV_SAS_WRITE }}
       DSCI_AZ_BLOB_PROD_SAS: ${{ secrets.DSCI_AZ_BLOB_PROD_SAS }}
+      DSCI_AWS_EMAIL_HOST: ${{ secrets.DSCI_AWS_EMAIL_HOST }}
+      DSCI_AWS_EMAIL_PORT: ${{ secrets.DSCI_AWS_EMAIL_PORT }}
+      DSCI_AWS_EMAIL_PASSWORD: ${{ secrets.DSCI_AWS_EMAIL_PASSWORD }}
+      DSCI_AWS_EMAIL_USERNAME: ${{ secrets.DSCI_AWS_EMAIL_USERNAME }}
+      DSCI_AWS_EMAIL_ADDRESS: ${{ secrets.DSCI_AWS_EMAIL_ADDRESS }}
+      TEST_EMAIL: ${{ inputs.TEST_EMAIL || 'true' }}
+      DRY_RUN: ${{ inputs.DRY_RUN || 'false' }}
+      FORCE_ALERT: ${{ inputs.FORCE_ALERT || 'false' }}
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
       with:
-        ref: forecast-monitor
+        ref: init-email-monitoring
 
     - name: Set up Python
       uses: actions/setup-python@v5
@@ -32,4 +63,4 @@ jobs:
 
     - name: Run script
       run: |
-        python pipelines/02_update_obsv_data.py
+        python pipelines/02_update_obsv_monitor.py


### PR DESCRIPTION

- This is just a quick update to to the workflow yaml files for main so that they can run on the `init-email-monitoring` branch now. I just copied the yamls from that branch and brought them in here.


* Renamed workflows to `Forecast Monitor` and `Observational Monitor`
* updated env vars generally including adding required input options for `TEST_EMAIL`, `DRY_RUN`, and `FORCE_ALERT`, upd
* Updated script references to `01_update_fcast_monitor.py` and `02_update_obsv_monitor.py`