### PR TITLE
Simplify dummy data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ book_cub_hurricanes/**/*.png
 
 book_cub_hurricanes/_book/*
 book_cub_hurricanes/_freeze/*
+
+scrap_copilot/*
+src/haiti_email/*

--- a/src/constants.py
+++ b/src/constants.py
@@ -53,7 +53,7 @@ D_THRESH = 230
 THRESHS = {
     "readiness": {"s": 120, "lt_days": 5},
     "action": {"s": 120, "lt_days": 3},
-    "obsv": {"p": 98, "s": 100},  # NEED TO UPDATE FOR PROD
+    "obsv": {"p": 98.2, "s": 105},  # NEED TO UPDATE FOR PROD
 }
 
 MIN_EMAIL_DISTANCE = 1000
@@ -114,3 +114,10 @@ LON_ZOOM_RANGE = np.array(
         360.0,
     ]
 )
+
+
+TEST_ATCF_ID = "TEST_ATCF_ID"
+TEST_MONITOR_ID = "TEST_MONITOR_ID"
+TEST_FCAST_MONITOR_ID = "TEST_FCAST_MONITOR_ID"
+TEST_OBSV_MONITOR_ID = "TEST_OBSV_MONITOR_ID"
+TEST_STORM_NAME = "TEST_STORM_NAME"

--- a/src/constants.py
+++ b/src/constants.py
@@ -1,12 +1,17 @@
 import numpy as np
 import os
+import pytz
 from datetime import datetime, timezone
 
 PROJECT_PREFIX = "ds-aa-cub-hurricanes"
 ISO3 = "cub"
 
 # Monitoring start date - only process data from this date forward
-MONITORING_START_DATE = datetime(2025, 1, 1, tzinfo=timezone.utc)
+# Set to Cuba timezone so that dummy emails show intended date
+cuba_tz = pytz.timezone("America/Havana")
+MONITORING_START_DATE = cuba_tz.localize(datetime(2025, 1, 1)).astimezone(
+    timezone.utc
+)
 
 
 # Runtime control flags - centralized configuration

--- a/src/datasources/nhc.py
+++ b/src/datasources/nhc.py
@@ -164,6 +164,24 @@ def load_historical_forecasts(include_geometry: bool = False):
         return df
 
 
+def load_recent_glb_nhc(fcast_obsv: str = "fcast"):
+    """
+    Load the most recent NHC forecast or observed tracks.
+
+    Parameters:
+    fcast_obsv (str): "fcast" for forecasts, "obsv" for observations.
+
+    Returns:
+    pd.DataFrame: DataFrame containing the tracks.
+    """
+    if fcast_obsv == "fcast":
+        return load_recent_glb_forecasts()
+    elif fcast_obsv == "obsv":
+        return load_recent_glb_obsv()
+    else:
+        raise ValueError("fcast_obsv must be 'fcast' or 'obsv'")
+
+
 def load_recent_glb_forecasts():
     return stratus.load_csv_from_blob(
         "noaa/nhc/forecasted_tracks.csv",

--- a/src/email/plotting.py
+++ b/src/email/plotting.py
@@ -522,7 +522,8 @@ def create_map_plot_figure(
         center_lat = (lat_max + lat_min) / 2
         center_lon = (lon_max + lon_min) / 2
     else:
-        zoom = 5.8
+        # Static Cuba-centered view for observations with lower zoom
+        zoom = 4.5  # Lowered from 5.8 to show more area
         center_lat = centroid_lat
         center_lon = centroid_lon
 

--- a/src/email/preview.py
+++ b/src/email/preview.py
@@ -20,10 +20,20 @@ from src.email.utils import (
     STATIC_DIR,
     TEMPLATES_DIR,
     FORCE_ALERT,
+    DRY_RUN,
+    TEST_EMAIL,
     load_monitoring_data,
 )
 from src.monitoring import monitoring_utils
 import ocha_stratus as stratus
+
+
+def show_environment_status():
+    """Display current environment variable settings for debugging."""
+    print("🔧 Environment Variables:")
+    print(f"   DRY_RUN: {DRY_RUN}")
+    print(f"   TEST_EMAIL: {TEST_EMAIL}")
+    print(f"   FORCE_ALERT: {FORCE_ALERT}")
 
 
 def get_image_as_base64(
@@ -91,6 +101,9 @@ def preview_info_email(
     --------
     dict: Contains 'html', 'text', 'subject', and other email details
     """
+    # Show environment status for debugging
+    show_environment_status()
+
     # Use the simplified email creation logic
     email_content = create_info_email_content(
         monitor_id, fcast_obsv, for_preview=True
@@ -207,6 +220,9 @@ def preview_trigger_email(
     --------
     dict: Contains 'html', 'text', 'subject', and other email details
     """
+    # Show environment status for debugging
+    show_environment_status()
+
     fcast_obsv = "fcast" if trigger_name in ["readiness", "action"] else "obsv"
 
     # Load monitoring data using the simplified API

--- a/src/email/templates/readiness.html
+++ b/src/email/templates/readiness.html
@@ -2,20 +2,25 @@
 
 {% block content %}
 <div>
-  <p>Estimado/a Coordinador/a Residente, estimados/as socios</p>
+  <p>Estimada coordinadora humanitaria, estimados colegas,</p>
   <p>
-    Después de haberlo confirmado con el gobierno y de acuerdo con lo indicado
-    por los pronósticos queremos informarles que se ha alcanzado el
-    desencadenante de alistamiento del marco de acción anticipatoria coordinada
-    para huracanes y tormentas en Cuba, conforme al pronóstico a 120 horas.
-  <p>
-    Se proporcionarán actualizaciones adicionales según corresponda.
-  </p>
-  Gracias por su continuo compromiso con la acción anticipatoria.
+    El umbral del activador de preparación del marco de acción anticipatoria para huracanes en Cuba ha sido alcanzado,
+    conforme al pronóstico emitido a las {{ pub_time }}, {{ pub_date }} (hora local de Cuba) por el Centro Nacional de
+    Huracanes de NOAA, el operador del Centro Meteorológico Regional Especializado Miami. El <a
+      href="https://www.insmet.cu/">Comunicado de actividad
+      ciclónica</a> publicado por el Instituto de Meteorología de Cuba confirma los pronósticos de NOAA.
   </p>
   <p>
-    Atentamente,
+    Las actividades de preparación conforme al <a href="INSERT_LINK">documento del
+      marco</a> deben comenzar ahora. El financiamiento del CERF destinado a las agencias de las Naciones Unidas está
+    siendo desbloqueado de manera automática. OCHA puede convocar una reunión de los socios participantes.
   </p>
+  <p>Saludos cordiales y buena suerte,</p>
   <p>Centro de Datos Humanitarios OCHA</p>
+  <p>
+    PD: No olviden que el impacto de este proyecto piloto será evaluado y alentamos a todos los socios a documentar de
+    la mejor manera las decisiones y lecciones aprendidas durante esta activación. Finalmente, por favor asegúrense
+    también de que todos los visuales, historias y medios sociales sean compartidos con el grupo.
+  </p>
 </div>
 {% endblock content %}

--- a/src/email/templates/readiness_official.html
+++ b/src/email/templates/readiness_official.html
@@ -1,0 +1,21 @@
+{% extends "base.html" %}
+
+{% block content %}
+<div>
+    <p>Estimado/a Coordinador/a Residente, estimados/as socios</p>
+    <p>
+        Después de haberlo confirmado con el gobierno y de acuerdo con lo indicado
+        por los pronósticos queremos informarles que se ha alcanzado el
+        desencadenante de alistamiento del marco de acción anticipatoria coordinada
+        para huracanes y tormentas en Cuba, conforme al pronóstico a 120 horas.
+    <p>
+        Se proporcionarán actualizaciones adicionales según corresponda.
+    </p>
+    Gracias por su continuo compromiso con la acción anticipatoria.
+    </p>
+    <p>
+        Atentamente,
+    </p>
+    <p>Centro de Datos Humanitarios OCHA</p>
+</div>
+{% endblock content %}

--- a/src/email/update_emails.py
+++ b/src/email/update_emails.py
@@ -23,6 +23,23 @@ def update_obsv_info_emails(verbose: bool = False):
     df_monitoring = load_monitoring_data("obsv")
     df_existing_email_record = load_email_record_with_test_filtering(["info"])
 
+    # Log email eligibility summary with rainfall criteria
+    within_distance = df_monitoring[
+        df_monitoring["min_dist"] <= MIN_EMAIL_DISTANCE
+    ]
+    within_distance_and_rain = within_distance[
+        within_distance["rainfall_relevant"]
+    ]
+    
+    print("📧 Observational email eligibility check:")
+    print(f"   ✅ {len(within_distance)}/{len(df_monitoring)} storms within "
+          f"{MIN_EMAIL_DISTANCE}km")
+    print(f"   🌧️  {len(within_distance_and_rain)}/{len(within_distance)} "
+          f"have relevant rainfall")
+    
+    if len(within_distance_and_rain) == 0:
+        print("   ⚠️  No storms meet both distance AND rainfall criteria")
+    
     dicts = []
     for monitor_id, row in df_monitoring.set_index("monitor_id").iterrows():
         if row["min_dist"] > MIN_EMAIL_DISTANCE:

--- a/src/email/update_emails.py
+++ b/src/email/update_emails.py
@@ -30,16 +30,20 @@ def update_obsv_info_emails(verbose: bool = False):
     within_distance_and_rain = within_distance[
         within_distance["rainfall_relevant"]
     ]
-    
+
     print("📧 Observational email eligibility check:")
-    print(f"   ✅ {len(within_distance)}/{len(df_monitoring)} storms within "
-          f"{MIN_EMAIL_DISTANCE}km")
-    print(f"   🌧️  {len(within_distance_and_rain)}/{len(within_distance)} "
-          f"have relevant rainfall")
-    
+    print(
+        f"   ✅ {len(within_distance)}/{len(df_monitoring)} storms within "
+        f"{MIN_EMAIL_DISTANCE}km"
+    )
+    print(
+        f"   🌧️  {len(within_distance_and_rain)}/{len(within_distance)} "
+        f"have relevant rainfall"
+    )
+
     if len(within_distance_and_rain) == 0:
         print("   ⚠️  No storms meet both distance AND rainfall criteria")
-    
+
     dicts = []
     for monitor_id, row in df_monitoring.set_index("monitor_id").iterrows():
         if row["min_dist"] > MIN_EMAIL_DISTANCE:

--- a/src/email/utils.py
+++ b/src/email/utils.py
@@ -64,6 +64,9 @@ def create_dummy_storm_tracks(
         # Sort by time to ensure proper chronological order
         dummy_track = dummy_track.sort_values("lastUpdate")
 
+        # Replace 100-knot values with 105 knots to create threshold crossing
+        dummy_track.loc[dummy_track["intensity"] == 100, "intensity"] = 105
+
         # Find first point where wind crosses observation threshold (105 knots)
         obs_threshold = THRESHS["obsv"]["s"]  # 105 knots
         threshold_crossed_idx = dummy_track[
@@ -136,8 +139,10 @@ def create_dummy_storm_monitoring(fcast_obsv: str) -> pd.DataFrame:
 
         # Calculate when the threshold would be crossed based on dummy data
         # In the dummy Hurricane Rafael data, threshold crossing happens
-        # around day 3 of the storm track
-        threshold_crossing_date = MONITORING_START_DATE + pd.Timedelta(days=3)
+        # around day 3 of the storm track (specifically at 09:00 on day 4)
+        threshold_crossing_date = MONITORING_START_DATE + pd.Timedelta(
+            days=3, hours=12
+        )
 
         df = pd.DataFrame(
             [


### PR DESCRIPTION
the previous logic for introducing dummy data didn't really work for observational because we had no observational data that would have crossed in the current nhc pipeline. Therefore, I just created dummy data in a different way. This allows the threshold in constants to be set for production as well rather than lowered just for testing