### PR TITLE
feat(plotting): ✨ add observational data loading for email scatter plot

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,12 @@ export TEST_EMAIL=true
 export FORCE_ALERT=true
 python your_script.py
 ```
+or like:
+
+```bash
+TEST_EMAIL=true DRY_RUN=false FORCE_ALERT=true python pipelines/01_update_fcast_monitor.py
+```
+
 
 ### Testing Override
 

--- a/book_cub_hurricanes/plot_optimization.qmd
+++ b/book_cub_hurricanes/plot_optimization.qmd
@@ -318,3 +318,14 @@ display(
     .format({"Total Affected": "{:,}"})
 )
 ```
+
+## Data for email scatter plot
+
+Just quickly adding this for easy reference - later. Should clean up where this goes.
+```{python}
+blob_name = (
+      f"{PROJECT_PREFIX}/processed/storm_stats/stats_with_targets.parquet"
+)
+
+df_stats_raw = stratus.load_parquet_from_blob(blob_name)
+```

--- a/pipelines/email_with_embedded_images.py
+++ b/pipelines/email_with_embedded_images.py
@@ -148,6 +148,9 @@ def send_hurricane_report():
     try:
         blob_name = f"{PROJECT_PREFIX}/email/test_distribution_list.csv"
         df_distribution = stratus.load_csv_from_blob(blob_name)
+        df_distribution = df_distribution[
+            df_distribution["daily_summary"].notna()
+        ]
         email_list = df_distribution["email"].tolist()
         EMAIL_TO = ", ".join(email_list)
         print(f"✅ Loaded {len(email_list)} emails from distribution list")

--- a/src/constants.py
+++ b/src/constants.py
@@ -28,6 +28,13 @@ DRY_RUN = _parse_bool_env("DRY_RUN", default=True)  # Safe default
 TEST_EMAIL = _parse_bool_env("TEST_EMAIL", default=True)  # Safe default
 FORCE_ALERT = _parse_bool_env("FORCE_ALERT", default=False)  # Off by default
 
+
+# this would actually be a better replacement way to deal w/ env vars
+# in the long run
+# def force_alert():
+#     return _parse_bool_env("FORCE_ALERT", default=False)
+
+
 # Saffir-Simpson scale (knots)
 TS = 34
 CAT1 = 64

--- a/src/email/plotting.py
+++ b/src/email/plotting.py
@@ -265,7 +265,7 @@ def create_1d_plot(stats, monitoring_point):
         fontsize=9,
     )
 
-    ax.set_xlim(left=0, right=155)
+    ax.set_xlim(left=0, right=175)
     ax.set_ylim(bottom=0, top=1)
 
     # Hide y-axis as it's just for display purposes
@@ -317,7 +317,7 @@ def create_2d_plot(stats, monitoring_point):
     rain_col = "q80_roll2"
     s_thresh = THRESHS["obsv"]["s"]
     rain_thresh = THRESHS["obsv"]["p"]
-    rain_ymax = 170
+    rain_ymax = 190
     rain_source_str = "IMERG"
     fcast_obsv_es = "observaciones"
     no_pass_text = "no ha pasado"
@@ -406,13 +406,13 @@ def create_2d_plot(stats, monitoring_point):
         fontstyle="italic",
     )
 
-    ax.set_xlim(right=155, left=0)
+    ax.set_xlim(right=175, left=0)
     ax.set_ylim(top=rain_ymax, bottom=0)
 
     ax.set_xlabel("Velocidad máxima del viento (nudos)")
     ax.set_ylabel(
         "Precipitaciones durante dos días consecutivos máximo,\n"
-        f"promedio sobre toda la superficie (mm, {rain_source_str})"
+        f"percentil 80 sobre toda la superficie (mm, {rain_source_str})"
     )
     ax.spines["top"].set_visible(False)
     ax.spines["right"].set_visible(False)

--- a/src/email/plotting.py
+++ b/src/email/plotting.py
@@ -12,9 +12,9 @@ from src.constants import (
     CERF_SIDS,
     CHD_GREEN,
     D_THRESH,
-    MIN_EMAIL_DISTANCE,
     SPANISH_MONTHS,
     LON_ZOOM_RANGE,
+    MIN_EMAIL_DISTANCE,
     PROJECT_PREFIX,
     THRESHS,
     FORCE_ALERT,
@@ -55,6 +55,7 @@ def update_plots(
     )
 
     # Log email eligibility summary
+    # Info emails use MIN_EMAIL_DISTANCE criteria, not ZMA
     eligible_df = df_monitoring[
         df_monitoring["min_dist"] <= MIN_EMAIL_DISTANCE
     ]
@@ -115,24 +116,24 @@ def update_plots(
             )
     else:
         print(
-            f"   ⚠️  No storms within {MIN_EMAIL_DISTANCE}km threshold "
+            f"   ⚠️  No storms within {MIN_EMAIL_DISTANCE}km "
             f"(no plots to create)"
         )
 
     if skipped_count > 0:
         print(
-            f"   ⏭️  {skipped_count} storms beyond {MIN_EMAIL_DISTANCE}km "
+            f"   ⏭️  {skipped_count} storms beyond distance threshold "
             f"(skipping plots)"
         )
 
     for monitor_id, row in df_monitoring.set_index("monitor_id").iterrows():
-        # Skip plots for storms beyond email distance threshold
+        # Skip plots for storms beyond distance threshold
+        # (info emails use MIN_EMAIL_DISTANCE)
         if row["min_dist"] > MIN_EMAIL_DISTANCE:
             if verbose:
                 print(
                     f"Skipping plots for {monitor_id}: "
-                    f"distance {row['min_dist']:.1f}km > "
-                    f"{MIN_EMAIL_DISTANCE}km"
+                    f"storm beyond {MIN_EMAIL_DISTANCE}km threshold"
                 )
             continue
 
@@ -278,14 +279,14 @@ def create_1d_plot(stats, monitoring_point):
     ax.spines["left"].set_visible(False)
 
     ax.set_title(
-        f"Comparación de velocidad del viento e impacto\n"
-        f"Zona de Máxima Atención",
+        "Comparación de velocidad del viento e impacto\n"
+        "Zona de Máxima Atención",
         fontsize=12,
         pad=20,
     )
 
-    # Add overlay if storm is beyond threshold
-    if monitoring_point["min_dist"] >= D_THRESH:
+    # Add overlay if storm is outside ZMA
+    if not monitoring_point["in_zma"]:
         rect = plt.Rectangle(
             (0, 0),
             1,
@@ -300,7 +301,7 @@ def create_1d_plot(stats, monitoring_point):
             0.5,
             0.5,
             f"{cyclone_name} {no_pass_text}\n"
-            f"a menos de {D_THRESH} km de Cuba",
+            "por la Zona de Máxima Atención",
             fontsize=30,
             color="grey",
             ha="center",
@@ -417,12 +418,12 @@ def create_2d_plot(stats, monitoring_point):
     ax.spines["top"].set_visible(False)
     ax.spines["right"].set_visible(False)
     ax.set_title(
-        f"Comparación de precipitaciones, viento, e impacto\n"
-        f"Zona de Máxima Atención",
+        "Comparación de precipitaciones, viento, e impacto\n"
+        "Zona de Máxima Atención",
     )
 
-    # Add overlay if storm is beyond threshold
-    if monitoring_point["min_dist"] >= D_THRESH:
+    # Add overlay if storm is outside ZMA
+    if not monitoring_point["in_zma"]:
         rect = plt.Rectangle(
             (0, 0),
             1,
@@ -437,7 +438,7 @@ def create_2d_plot(stats, monitoring_point):
             0.5,
             0.5,
             f"{cyclone_name} {no_pass_text}\n"
-            f"a menos de {D_THRESH} km de Cuba",
+            "por la Zona de Máxima Atención",
             fontsize=30,
             color="grey",
             ha="center",

--- a/src/email/plotting.py
+++ b/src/email/plotting.py
@@ -159,82 +159,177 @@ def create_plot(
         raise ValueError(f"Unknown plot type: {plot_type}")
 
 
-def create_scatter_plot(monitor_id: str, fcast_obsv: Literal["fcast", "obsv"]):
+def create_1d_plot(stats, monitoring_point):
+    """Create a 1D wind speed plot for forecast data."""
+    # Hardcode forecast-specific parameters
+    s_thresh = THRESHS["readiness"]["s"]
+    fcast_obsv_es = "pronósticos"
+    no_pass_text = "no está previsto que pase"
 
-    # Check if statistics file exists first, before loading data
-    # blob_name = f"{PROJECT_PREFIX}/processed/stats_{D_THRESH}km.csv"
-
-    blob_name = (
-        f"{PROJECT_PREFIX}/processed/storm_stats/stats_with_targets.parquet"
-    )
-    # df_stats = stratus.load_parquet_from_blob(blob_name)
-
-    try:
-        stats = stratus.load_parquet_from_blob(blob_name)
-        # stats = stratus.load_csv_from_blob(blob_name)
-    except Exception as e:
-        print(f"⚠️  Could not load statistics file {blob_name}: {e}")
-        print(f"⚠️  Skipping scatter plot creation for {monitor_id}")
-        return
-
-    df_monitoring = load_monitoring_data(fcast_obsv)
-    monitoring_point = df_monitoring.set_index("monitor_id").loc[monitor_id]
-    cuba_tz = pytz.timezone("America/Havana")
+    # Extract needed values from monitoring_point
     cyclone_name = monitoring_point["name"]
+    current_s = monitoring_point["readiness_s"]
     issue_time = monitoring_point["issue_time"]
+    cuba_tz = pytz.timezone("America/Havana")
     issue_time_cuba = issue_time.astimezone(cuba_tz)
-    if fcast_obsv == "fcast":
-        rain_plot_var = None  # No precipitation variables for forecast
-        s_plot_var = "readiness_s"
-        rain_col = "max_roll2_sum_rain"
-        rain_source_str = "CHIRPS"
-        rain_ymax = 100
-        s_thresh = THRESHS["readiness"]["s"]
-        rain_thresh = None  # No rain threshold for forecast
-        fcast_obsv_es = "pronósticos"
-        no_pass_text = "no está previsto que pase"
-    else:
-        rain_plot_var = "obsv_p"
-        s_plot_var = "obsv_s"
-        rain_col = "q80_roll2"
-        rain_source_str = "IMERG"
-        rain_ymax = 170
-        s_thresh = THRESHS["obsv"]["s"]
-        rain_thresh = THRESHS["obsv"]["p"]
-        fcast_obsv_es = "observaciones"
-        no_pass_text = "no ha pasado"
-
-    # Don't need this anymore
-    # def sid_color(sid):
-    #     color = "blue"
-    #     if sid in CERF_SIDS:
-    #         color = "red"
-    #     return color
-
-    stats["color"] = stats["cerf_str"].apply(
-        lambda x: "red" if x == "True" else "blue"
-    )
-
-    # minor wrangling to fit func
-    # rename inplace cool
-    stats.rename(
-        columns={"Total Affected": "affected_population"}, inplace=True
-    )
-    stats["year"] = stats["valid_time_min"].dt.year
-    stats["marker_size"] = stats["affected_population"] / 6e2
-    stats["marker_size"] = stats["marker_size"].fillna(1)
-    # stats["color"] = stats["sid"].apply(sid_color)
-    current_p = monitoring_point[rain_plot_var] if rain_plot_var else None
-    current_s = monitoring_point[s_plot_var]
     issue_time_str_es = convert_datetime_to_es_str(issue_time_cuba)
 
-    date_str = (
-        f"Pronóstico "
-        f'{monitoring_point["issue_time"].strftime("%Hh%M %d %b UTC")}'
+    fig, ax = plt.subplots(figsize=(10, 6), dpi=300)
+
+    # Create 1D plot along x-axis (wind speed) with random jitter
+    y_positions = np.random.normal(0.5, 0.1, len(stats))
+
+    ax.scatter(
+        stats["wind_speed_max"],
+        y_positions,
+        s=stats["marker_size"],
+        c=stats["color"],
+        alpha=0.6,
+        edgecolors="none",
     )
 
-    for en_mo, es_mo in SPANISH_MONTHS.items():
-        date_str = date_str.replace(en_mo, es_mo)
+    # Add storm name annotations
+    for j, txt in enumerate(
+        stats["name"].str.capitalize() + "\n" + stats["year"].astype(str)
+    ):
+        ax.annotate(
+            txt.capitalize(),
+            (stats["wind_speed_max"][j] + 0.5, y_positions[j]),
+            ha="left",
+            va="center",
+            fontsize=7,
+        )
+
+    # Mark current storm
+    current_y = 0.5  # Center position
+    ax.scatter(
+        [current_s],
+        [current_y],
+        marker="x",
+        color=CHD_GREEN,
+        linewidths=4,
+        s=150,
+        zorder=10,
+    )
+    ax.annotate(
+        f"{cyclone_name}",
+        (current_s, current_y + 0.15),
+        va="center",
+        ha="center",
+        color=CHD_GREEN,
+        fontweight="bold",
+        fontsize=10,
+    )
+    ax.annotate(
+        f"{fcast_obsv_es} emitidas {issue_time_str_es}",
+        (current_s, current_y - 0.15),
+        va="center",
+        ha="center",
+        color=CHD_GREEN,
+        fontstyle="italic",
+        fontsize=8,
+    )
+
+    # Add threshold line
+    ax.axvline(
+        x=s_thresh, color="orange", linewidth=2, linestyle="--", alpha=0.8
+    )
+    ax.fill_betweenx(
+        [0, 1],
+        s_thresh,
+        155,
+        color="gold",
+        alpha=0.2,
+        zorder=-1,
+    )
+
+    # Threshold annotation
+    ax.annotate(
+        "Umbral de activación",
+        (s_thresh + 2, 0.9),
+        ha="left",
+        va="top",
+        color="orange",
+        fontweight="bold",
+        fontsize=9,
+    )
+
+    # CERF legend
+    ax.annotate(
+        "Asignaciones CERF en rojo",
+        (5, 0.9),
+        ha="left",
+        va="top",
+        color="crimson",
+        fontstyle="italic",
+        fontsize=9,
+    )
+
+    ax.set_xlim(left=0, right=155)
+    ax.set_ylim(bottom=0, top=1)
+
+    # Hide y-axis as it's just for display purposes
+    ax.set_yticks([])
+    ax.set_xlabel("Velocidad máxima del viento (nudos)", fontsize=12)
+    ax.set_ylabel("")
+
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+    ax.spines["left"].set_visible(False)
+
+    ax.set_title(
+        f"Comparación de velocidad del viento e impacto\n"
+        f"Zona de Máxima Atención",
+        fontsize=12,
+        pad=20,
+    )
+
+    # Add overlay if storm is beyond threshold
+    if monitoring_point["min_dist"] >= D_THRESH:
+        rect = plt.Rectangle(
+            (0, 0),
+            1,
+            1,
+            transform=ax.transAxes,
+            color="white",
+            alpha=0.7,
+            zorder=3,
+        )
+        ax.add_patch(rect)
+        ax.text(
+            0.5,
+            0.5,
+            f"{cyclone_name} {no_pass_text}\n"
+            f"a menos de {D_THRESH} km de Cuba",
+            fontsize=30,
+            color="grey",
+            ha="center",
+            va="center",
+            transform=ax.transAxes,
+        )
+
+    return fig, ax
+
+
+def create_2d_plot(stats, monitoring_point):
+    """Create a 2D scatter plot for observation data."""
+    # Hardcode observation-specific parameters
+    rain_col = "q80_roll2"
+    s_thresh = THRESHS["obsv"]["s"]
+    rain_thresh = THRESHS["obsv"]["p"]
+    rain_ymax = 170
+    rain_source_str = "IMERG"
+    fcast_obsv_es = "observaciones"
+    no_pass_text = "no ha pasado"
+
+    # Extract needed values from monitoring_point
+    cyclone_name = monitoring_point["name"]
+    current_s = monitoring_point["obsv_s"]
+    current_p = monitoring_point["obsv_p"]
+    issue_time = monitoring_point["issue_time"]
+    cuba_tz = pytz.timezone("America/Havana")
+    issue_time_cuba = issue_time.astimezone(cuba_tz)
+    issue_time_str_es = convert_datetime_to_es_str(issue_time_cuba)
 
     fig, ax = plt.subplots(figsize=(8, 8), dpi=300)
 
@@ -326,6 +421,7 @@ def create_scatter_plot(monitor_id: str, fcast_obsv: Literal["fcast", "obsv"]):
         f"Umbral de distancia = {D_THRESH} km"
     )
 
+    # Add overlay if storm is beyond threshold
     if monitoring_point["min_dist"] >= D_THRESH:
         rect = plt.Rectangle(
             (0, 0),
@@ -348,6 +444,44 @@ def create_scatter_plot(monitor_id: str, fcast_obsv: Literal["fcast", "obsv"]):
             va="center",
             transform=ax.transAxes,
         )
+
+    return fig, ax
+
+
+def create_scatter_plot(monitor_id: str, fcast_obsv: Literal["fcast", "obsv"]):
+    # Check if statistics file exists first, before loading data
+    blob_name = (
+        f"{PROJECT_PREFIX}/processed/storm_stats/stats_with_targets.parquet"
+    )
+
+    try:
+        stats = stratus.load_parquet_from_blob(blob_name)
+    except Exception as e:
+        print(f"⚠️  Could not load statistics file {blob_name}: {e}")
+        print(f"⚠️  Skipping scatter plot creation for {monitor_id}")
+        return
+
+    df_monitoring = load_monitoring_data(fcast_obsv)
+    monitoring_point = df_monitoring.set_index("monitor_id").loc[monitor_id]
+
+    # Process stats data (common for both plot types)
+    stats["color"] = stats["cerf_str"].apply(
+        lambda x: "red" if x == "True" else "blue"
+    )
+    stats.rename(
+        columns={"Total Affected": "affected_population"}, inplace=True
+    )
+    stats["year"] = stats["valid_time_min"].dt.year
+    stats["marker_size"] = stats["affected_population"] / 6e2
+    stats["marker_size"] = stats["marker_size"].fillna(1)
+
+    # Create plot based on fcast_obsv type
+    if fcast_obsv == "fcast":
+        fig, ax = create_1d_plot(stats, monitoring_point)
+    else:
+        fig, ax = create_2d_plot(stats, monitoring_point)
+
+    # Common save logic
     buffer = io.BytesIO()
     fig.savefig(buffer, format="png", dpi=150, bbox_inches="tight")
     buffer.seek(0)

--- a/src/email/plotting.py
+++ b/src/email/plotting.py
@@ -418,7 +418,7 @@ def create_2d_plot(stats, monitoring_point):
     ax.spines["right"].set_visible(False)
     ax.set_title(
         f"Comparación de precipitaciones, viento, e impacto\n"
-        f"Umbral de distancia = {D_THRESH} km"
+        f"Zona de Máxima Atención",
     )
 
     # Add overlay if storm is beyond threshold

--- a/src/monitoring/monitoring_utils.py
+++ b/src/monitoring/monitoring_utils.py
@@ -500,6 +500,10 @@ class CubaHurricaneMonitor:
 
             closest_row = closest_stats["closest_row"]
 
+            # Check if storm intersects ZMA
+            gdf_zma = self._filter_by_zma(gdf)
+            in_zma = not gdf_zma.empty
+
             # Calculate trigger statistics
             action_stats = self._get_wind_trigger_stats(
                 gdf, "action", use_leadtime=True
@@ -521,6 +525,7 @@ class CubaHurricaneMonitor:
                 "past_cutoff": closest_row["leadtime"]
                 < pd.Timedelta(hours=72),  # Using 72 hours as default
                 "min_dist": closest_stats["min_dist"],
+                "in_zma": in_zma,
                 **action_stats,
                 **readiness_stats,
             }
@@ -560,6 +565,7 @@ class CubaHurricaneMonitor:
 
             # Calculate observational trigger based on ZMA intersection
             gdf_zma = self._filter_by_zma(gdf_recent)
+            in_zma = not gdf_zma.empty
 
             if gdf_zma.empty:
                 logger.info(
@@ -605,6 +611,7 @@ class CubaHurricaneMonitor:
                 "name": name,
                 "issue_time": issue_time,
                 "min_dist": closest_stats["min_dist"],
+                "in_zma": in_zma,
                 "closest_s": closest_s,
                 "closest_p": closest_p,
                 "obsv_s": max_s,
@@ -1117,6 +1124,10 @@ class CubaHurricaneMonitor:
 
             closest_row = closest_stats["closest_row"]
 
+            # Check if storm intersects ZMA
+            gdf_zma = self._filter_by_zma(gdf)
+            in_zma = not gdf_zma.empty
+
             # Calculate observational trigger (no leadtime filtering)
             obsv_stats = self._get_wind_trigger_stats(
                 gdf, "obsv", wind_col="intensity", use_leadtime=False
@@ -1131,6 +1142,7 @@ class CubaHurricaneMonitor:
                 "name": group_recent["name"].iloc[-1],
                 "issue_time": issue_time,
                 "min_dist": closest_stats["min_dist"],
+                "in_zma": in_zma,
                 "closest_s": closest_row["intensity"],
                 **obsv_stats,
             }


### PR DESCRIPTION
Haiti scatter plot data pulls in a historical csv for providing data for the plot. This csv was not available, but I found the parquet file that most resembles it (i think). Therefore I switched the source and do some minor data wrangling to make the data.frame fit the function used in haiti

I still need to configure plotting/wrangling for case when plotting forecast rather than observational.

## Autogenerated from copilot:

 pull request updates the data source and refines the data wrangling for the email scatter plot feature. The main change is switching from a CSV to a Parquet file for storm statistics, which enables more efficient data loading and processing. Additionally, several column names and data preparation steps have been updated to match the new data format and requirements.

**Data wrangling and column updates:**

* Updated `create_scatter_plot` to use the new data source.
* Updated column references to match the new Parquet schema, including renaming `max_wind` to `wind_speed_max` and `max_roll2_sum_rain_imerg` to `q80_roll2` for plotting. [[1]](diffhunk://#diff-cafaa1273726f018ec105a264a2bf0ab9feb8659b6047964c380076da17fcf6fL191-R226) [[2]](diffhunk://#diff-cafaa1273726f018ec105a264a2bf0ab9feb8659b6047964c380076da17fcf6fL223-R242) [[3]](diffhunk://#diff-cafaa1273726f018ec105a264a2bf0ab9feb8659b6047964c380076da17fcf6fL236-R255)
* Added logic to set the color of scatter plot points based on the `cerf_str` column, replacing the previous `sid_color` function.
* Renamed `Total Affected` to `affected_population` and extracted the year from the `valid_time_min` column for additional data context.* Introduced loading of storm statistics from a new parquet file.
* Removed unused color assignment function for simplicity.