### PR TITLE
Keep repo awake

### DIFF
--- a/.github/workflows/keep_awake.yml
+++ b/.github/workflows/keep_awake.yml
@@ -23,5 +23,5 @@ jobs:
 
         - name: Commit and Push Changes
           run: |
-            git commit --allow-empty -m "Keep repo awake"
+            git commit --allow-empty -m "Keep repo awake [skip ci]"
             git push origin keep-awake


### PR DESCRIPTION
Adding simple GHA to keep repo awake and prevent other GHAs from being automatically disabled. Pushes empty commit to `keep-awake` branch.