### PR TITLE
fix(workflows): 🔧 Update default value of `TEST_EMAIL` to "false"

### DIFF
--- a/.github/workflows/01_run_forecast_data_ingestion.yml
+++ b/.github/workflows/01_run_forecast_data_ingestion.yml
@@ -6,7 +6,7 @@ on:
         TEST_EMAIL:
           required: true
           type: choice
-          default: "true"
+          default: "false"
           options:
             - "true"
             - "false"

--- a/.github/workflows/02_run_observational_data_ingestion.yml
+++ b/.github/workflows/02_run_observational_data_ingestion.yml
@@ -6,7 +6,7 @@ on:
         TEST_EMAIL:
           required: true
           type: choice
-          default: "true"
+          default: "false"
           options:
             - "true"
             - "false"
@@ -39,7 +39,7 @@ jobs:
       DSCI_AWS_EMAIL_PASSWORD: ${{ secrets.DSCI_AWS_EMAIL_PASSWORD }}
       DSCI_AWS_EMAIL_USERNAME: ${{ secrets.DSCI_AWS_EMAIL_USERNAME }}
       DSCI_AWS_EMAIL_ADDRESS: ${{ secrets.DSCI_AWS_EMAIL_ADDRESS }}
-      TEST_EMAIL: ${{ inputs.TEST_EMAIL || 'true' }}
+      TEST_EMAIL: ${{ inputs.TEST_EMAIL || 'false' }}
       DRY_RUN: ${{ inputs.DRY_RUN || 'false' }}
       FORCE_ALERT: ${{ inputs.FORCE_ALERT || 'false' }}
 


### PR DESCRIPTION
I noticed the test_distribution_list was still being picked up from the latest informational emails. I THINK think this is because these are not run on a CRON job in this repo, but rather pinged/triggerd from the nhc pipeline repo which then respects the default settings in the workflow_dispatch which would otherwise be ignored by CRON run initiated in this repo