### PR TITLE
Population data validation + wind-footprint methodology map

### DIFF
--- a/book_cub_hurricanes/_quarto.yml
+++ b/book_cub_hurricanes/_quarto.yml
@@ -22,6 +22,7 @@ book:
     - chirps_gefs_raster_processing.qmd
     - summary.qmd
     - appendix_check_quantile_calc.qmd
+    - appendix_population_data.qmd
     - references.qmd
 
 bibliography: references.bib

--- a/book_cub_hurricanes/_quarto.yml
+++ b/book_cub_hurricanes/_quarto.yml
@@ -23,6 +23,7 @@ book:
     - summary.qmd
     - appendix_check_quantile_calc.qmd
     - appendix_population_data.qmd
+    - appendix_methodology_map.qmd
     - references.qmd
 
 bibliography: references.bib

--- a/book_cub_hurricanes/appendix_methodology_map.qmd
+++ b/book_cub_hurricanes/appendix_methodology_map.qmd
@@ -1,0 +1,50 @@
+---
+jupyter: ds-aa-cub-hurricanes
+---
+
+## Appendix 1C: Wind Footprint over Population
+
+This appendix is a visual illustration of the idea behind the wind-based
+trigger: a storm's wind-radii buffers are overlaid on the gridded population the
+framework uses to estimate exposure. It is not part of the calculation — it is a
+presentation aid that shows, for a single storm, how the wind footprint
+intersects where people actually live in Cuba.
+
+The figure below is for Hurricane Melissa (2025). It is produced by the
+standalone script `scripts/methodology_map.py` (included in full at the end of
+this appendix) and stored as a PNG in blob storage, which we load directly here.
+
+### Figure
+
+```{python}
+#| echo: false
+import ocha_stratus as stratus
+from IPython.display import Image
+from src.constants import PROJECT_PREFIX
+
+png_bytes = stratus.load_blob_data(
+    f"{PROJECT_PREFIX}/book_static/methodology_map_melissa.png",
+    container_name="projects",
+    stage="dev",
+)
+Image(data=png_bytes)
+```
+
+### How it is built
+
+- **Wind buffers** come from `storms.ibtracs_wind_buffers` — the same IBTrACS
+  wind-radii geometries used elsewhere in the analysis — drawn as the 34 / 50 /
+  64 kt rings, widest to tightest.
+- **Population** is the WorldPop 2026 1 km constrained raster
+  (`worldpop/pop_count/global_pop_2026_CN_1km_R2025A_UA_v1.tif`), windowed to
+  Cuba, coarsened, and rendered on an asinh ("pseudo-log") colour scale so that
+  both the sparse rural land and the dense cities read clearly on the same map.
+- **Boundaries** are the CODAB admin-0 and admin-1 polygons.
+
+The script renders any storm by friendly name (`ike`, `gustav`, `irma`, `ian`,
+`oscar`, `melissa`) or raw IBTrACS SID, and the `--upload` flag pushes the PNG to
+the blob location this page reads from. Its full source is included below for
+reference — it is displayed only, not executed when the book renders:
+
+```{.python include="../scripts/methodology_map.py"}
+```

--- a/book_cub_hurricanes/appendix_population_data.qmd
+++ b/book_cub_hurricanes/appendix_population_data.qmd
@@ -207,6 +207,157 @@ The only meaningful rank swap is Artemisa rising 2 places (9th → 11th in
 ONEI, but 9th in WorldPop), pushing Las Tunas and Guantánamo down one slot
 each. That is the same east-west reshape made visible on the rank scale.
 
+### Cross-checking at admin2
+
+If the shared-lineage story is right, we should see the same close agreement
+at admin2 (municipio). Both sources publish at this scale: CODAB has 168
+admin2 polygons, ONEI's `CUB_ADM2_POP_2024.xlsx` has 168 admin2 rows.
+
+The pcode systems do not match (CODAB uses `CU0201`, ONEI uses NaN for
+adm2 and `21`-style numeric for adm1), so the join is on
+`(adm1_name, adm2_name)` after Unicode normalisation. Nine municipios have
+typos or spelling variants on one side, plus two municipios both named
+"San Luis" (in Pinar del Río and Santiago de Cuba) — handled by the
+compound key.
+
+```{python}
+NAME_FIXES = {
+    "ciefuegos": "cienfuegos",
+    "ciro redodo": "ciro redondo",
+    "frak pais": "frank pais",
+    "aguada de pasajajeros": "aguada de pasajeros",
+    "carlos m. de cespedes": "carlos manuel de cespedes",
+    "habana del este": "la habana del este",
+    "habana vieja": "la habana vieja",
+    "manueltames": "manuel tames",
+    "songo - la maya": "songo-la maya",
+}
+
+
+def canonical(s: str) -> str:
+    n = (
+        unicodedata.normalize("NFKD", str(s))
+        .encode("ascii", "ignore")
+        .decode("ascii")
+        .strip()
+        .lower()
+    )
+    return NAME_FIXES.get(n, n)
+
+
+adm2 = stratus.load_shp_from_blob(
+    blob_name=f"{PROJECT_PREFIX}/raw/codab/cub.shp.zip",
+    shapefile="cub_adm2.shp",
+    stage="dev",
+)
+adm2["a1_k"] = adm2["ADM1_ES"].map(canonical)
+adm2["a2_k"] = adm2["ADM2_ES"].map(canonical)
+
+xlsx2_bytes = stratus.load_blob_data(
+    f"{PROJECT_PREFIX}/raw/unfpa/CUB_ADM2_POP_2024.xlsx",
+    container_name="projects",
+    stage="dev",
+)
+official2 = (
+    pd.read_excel(io.BytesIO(xlsx2_bytes), sheet_name="CUB_ADM2_POP_2024")[
+        ["ADM1_NAME", "ADM2_NAME", "T_TL"]
+    ]
+    .rename(columns={"T_TL": "pop_official"})
+    .assign(
+        a1_k=lambda d: d["ADM1_NAME"].map(canonical),
+        a2_k=lambda d: d["ADM2_NAME"].map(canonical),
+    )
+)
+
+adm2_joined = adm2.merge(
+    official2[["a1_k", "a2_k", "pop_official"]],
+    on=["a1_k", "a2_k"],
+    validate="one_to_one",
+)
+print(f"adm2 polygons joined: {len(adm2_joined)} / 168")
+```
+
+```{python}
+if str(adm2_joined.crs) != str(da.rio.crs):
+    adm2_joined = adm2_joined.to_crs(da.rio.crs)
+
+stats2 = exact_extract(
+    da,
+    adm2_joined,
+    ops=["sum"],
+    output="pandas",
+    include_cols=["ADM2_PCODE", "ADM2_ES", "ADM1_ES", "pop_official"],
+)
+sum2_col = next(
+    c for c in stats2.columns if c == "sum" or c.endswith("_sum")
+)
+stats2 = stats2.rename(columns={sum2_col: "pop_worldpop2026"})
+stats2["pct_diff"] = 100 * (stats2["pop_worldpop2026"] / stats2["pop_official"] - 1)
+
+print(
+    f"WP total: {stats2['pop_worldpop2026'].sum():>12,.0f}   "
+    f"ONEI total: {stats2['pop_official'].sum():>12,.0f}   "
+    f"diff: {100*(stats2['pop_worldpop2026'].sum()/stats2['pop_official'].sum()-1):+.2f}%"
+)
+r2 = np.corrcoef(stats2["pop_worldpop2026"], stats2["pop_official"])[0, 1]
+rho2 = np.corrcoef(
+    stats2["pop_worldpop2026"].rank(), stats2["pop_official"].rank()
+)[0, 1]
+print(f"Pearson r:    {r2:.4f}   (vs 0.997 at adm1)")
+print(f"Spearman rho: {rho2:.4f}   (vs 0.991 at adm1)")
+```
+
+The national total agrees with the adm1 zonal sum to within ~0.1% (the
+small difference is just CODAB adm2 vs. Field Maps adm1 polygon edge
+effects). But the per-municipio agreement is **much worse**: Pearson r
+drops from 0.997 (adm1) to 0.87 (adm2), and per-unit `pct_diff` ranges
+from −90% to +414%. The deviations are not noise — they concentrate in
+specific places.
+
+```{python}
+top = stats2.nlargest(5, "pct_diff")[
+    ["ADM2_ES", "ADM1_ES", "pop_worldpop2026", "pop_official", "pct_diff"]
+]
+bot = stats2.nsmallest(5, "pct_diff")[
+    ["ADM2_ES", "ADM1_ES", "pop_worldpop2026", "pop_official", "pct_diff"]
+]
+print("=== Largest positive deviations (WP > ONEI) ===")
+print(top.round(0).to_string(index=False))
+print("=== Largest negative deviations (WP < ONEI) ===")
+print(bot.round(0).to_string(index=False))
+```
+
+The pattern is striking: large positive *and* large negative deviations
+cluster inside **La Habana** province, often in adjacent municipios. Cerro
+shows +111% while neighbouring Arroyo Naranjo shows −87%. The two
+WorldPop estimates *do* sum back to roughly the ONEI provincial total —
+WorldPop just allocates the people across the urban core differently than
+ONEI's municipal census rows.
+
+**Why the adm1 result does not extend to adm2.** Two compounding causes:
+
+1. **WorldPop's input admin level is not CODAB's published 168.** The
+   Release Statement says WorldPop "nested" Cuba's units from 168 down to
+   161 for harmonisation between its 2012 and 2022 timepoints (a
+   pre-processing step to keep boundaries consistent across census
+   rounds). The dasymetric mathematical preservation only holds at *that*
+   nested input level — not at CODAB's published level. Extracting by
+   CODAB's 168 polygons cuts through several of WorldPop's merged input
+   units, and within each merged unit population is spread by the
+   random-forest density + built-settlement mask, not by ONEI's municipal
+   boundaries.
+2. **The raster is 1km, the municipios are small.** Habana's 15 municipios
+   range from ~14 km² (Centro Habana, Cerro) to ~250 km² (La Habana del
+   Este). At 1km resolution, the small dense ones span only ~14 pixels —
+   not nearly enough for the dasymetric allocation across a merged input
+   unit to recover ONEI's municipio counts.
+
+The shared-lineage logic does not break, then — it just becomes a
+constraint *on WorldPop's internal nested admin units*, not on every admin
+level a user might choose. At admin1, where many municipios aggregate
+together, the within-unit allocation noise averages out, and we see r =
+0.997. At admin2, that averaging is gone.
+
 ### Methodology context
 
 **ONEI projection.** The xlsx is ONEI's projection from the 2012 *Censo de
@@ -245,15 +396,22 @@ is marked as an **alpha** release by WorldPop, with refinements expected.
 
 ### What this means for the trigger framework
 
-- **Rank- or share-based comparisons across provinces are robust.** 13/16
-  ranks match exactly, all 16 shares match within 1.1 pp, and the
-  province-correlation is r ≈ 0.997. Exposure rankings used for
-  prioritisation are unaffected by the choice of dataset.
-- **Absolute counts are not robust.** Both datasets descend from the 2012
-  census via ONEI projections that do not reflect post-2020 emigration.
-  Independent estimates suggest the true end-2024 population is ~15–18%
-  lower than either number. If absolute "people affected" figures are
-  needed, they should be flagged with that uncertainty.
+- **At admin1, rank- and share-based comparisons are robust.** 13/16
+  ranks match exactly, all 16 shares match within 1.1 pp, and r ≈ 0.997.
+  Exposure rankings used for provincial prioritisation are insensitive to
+  the choice between WorldPop and ONEI.
+- **At admin2, the raster is not a reliable per-municipio estimator.**
+  Pearson r drops to 0.87, with per-municipio deviations of −90% to
+  +414% concentrated in dense urban Habana. The dasymetric preservation
+  property holds only at WorldPop's internal nested input units (~161
+  for Cuba), not at CODAB's published 168. For municipio-level exposure
+  numbers, use ONEI's adm2 directly rather than zonal sums from this
+  raster.
+- **Absolute counts are not robust at any level.** Both datasets descend
+  from the 2012 census via ONEI projections that do not reflect post-2020
+  emigration. Independent estimates suggest the true end-2024 population
+  is ~15–18% lower than either number. If absolute "people affected"
+  figures are needed, they should be flagged with that uncertainty.
 - **The +11% gap between WorldPop and the xlsx is not evidence about real
   population.** It is mostly a difference between UN WPP 2024 (WorldPop's
   national control) and ONEI's later 2025 projection (the xlsx). The

--- a/book_cub_hurricanes/appendix_population_data.qmd
+++ b/book_cub_hurricanes/appendix_population_data.qmd
@@ -209,40 +209,34 @@ each. That is the same east-west reshape made visible on the rank scale.
 
 ### Cross-checking at admin2
 
-If the shared-lineage story is right, we should see the same close agreement
-at admin2 (municipio). Both sources publish at this scale: CODAB has 168
-admin2 polygons, ONEI's `CUB_ADM2_POP_2024.xlsx` has 168 admin2 rows.
+If the shared-lineage story is right, we should see the same close
+agreement at admin2 (municipio). Both sources publish at this scale: CODAB
+has 168 admin2 polygons, ONEI's `CUB_ADM2_POP_2024.xlsx` has 168 rows.
 
-The pcode systems do not match (CODAB uses `CU0201`, ONEI uses NaN for
-adm2 and `21`-style numeric for adm1), so the join is on
-`(adm1_name, adm2_name)` after Unicode normalisation. Nine municipios have
-typos or spelling variants on one side, plus two municipios both named
-"San Luis" (in Pinar del Río and Santiago de Cuba) — handled by the
-compound key.
+The pcode systems do not match (CODAB uses `CU0201`-style, ONEI's adm2
+pcode column is NaN), so the join is on `(adm1_name, adm2_name)` after
+Unicode normalisation. The compound key also disambiguates two municipios
+called "San Luis" (one in Pinar del Río, one in Santiago de Cuba).
+
+A handful of municipio names have typos or spelling variants on one side
+(e.g. ONEI's `"aguada de pasajajeros"` vs. CODAB's `"aguada de pasajeros"`;
+ONEI's `"la habana del este"` vs. CODAB's `"habana del este"`). Rather
+than build a manual fix-up map and risk silently mis-matching, we apply a
+**stricter quality filter**: keep an admin1 only if *every* one of its
+admin2 names matches exactly between CODAB and ONEI under basic Unicode
+normalisation. If even one municipio in a province has uncertain name
+alignment, drop the whole province — because if names are uncertain,
+boundary alignment between the two sources is uncertain too.
 
 ```{python}
-NAME_FIXES = {
-    "ciefuegos": "cienfuegos",
-    "ciro redodo": "ciro redondo",
-    "frak pais": "frank pais",
-    "aguada de pasajajeros": "aguada de pasajeros",
-    "carlos m. de cespedes": "carlos manuel de cespedes",
-    "habana del este": "la habana del este",
-    "habana vieja": "la habana vieja",
-    "manueltames": "manuel tames",
-    "songo - la maya": "songo-la maya",
-}
-
-
-def canonical(s: str) -> str:
-    n = (
+def norm_basic(s: str) -> str:
+    return (
         unicodedata.normalize("NFKD", str(s))
         .encode("ascii", "ignore")
         .decode("ascii")
         .strip()
         .lower()
     )
-    return NAME_FIXES.get(n, n)
 
 
 adm2 = stratus.load_shp_from_blob(
@@ -250,8 +244,8 @@ adm2 = stratus.load_shp_from_blob(
     shapefile="cub_adm2.shp",
     stage="dev",
 )
-adm2["a1_k"] = adm2["ADM1_ES"].map(canonical)
-adm2["a2_k"] = adm2["ADM2_ES"].map(canonical)
+adm2["a1_k"] = adm2["ADM1_ES"].map(norm_basic)
+adm2["a2_k"] = adm2["ADM2_ES"].map(norm_basic)
 
 xlsx2_bytes = stratus.load_blob_data(
     f"{PROJECT_PREFIX}/raw/unfpa/CUB_ADM2_POP_2024.xlsx",
@@ -264,26 +258,40 @@ official2 = (
     ]
     .rename(columns={"T_TL": "pop_official"})
     .assign(
-        a1_k=lambda d: d["ADM1_NAME"].map(canonical),
-        a2_k=lambda d: d["ADM2_NAME"].map(canonical),
+        a1_k=lambda d: d["ADM1_NAME"].map(norm_basic),
+        a2_k=lambda d: d["ADM2_NAME"].map(norm_basic),
     )
 )
 
-adm2_joined = adm2.merge(
-    official2[["a1_k", "a2_k", "pop_official"]],
-    on=["a1_k", "a2_k"],
-    validate="one_to_one",
+# Keep admin1s where the set of adm2 names is identical in both sources
+def is_clean(a1_key: str) -> bool:
+    g = set(adm2.loc[adm2["a1_k"] == a1_key, "a2_k"])
+    o = set(official2.loc[official2["a1_k"] == a1_key, "a2_k"])
+    return bool(g) and g == o
+
+
+clean_a1 = sorted(
+    {a1 for a1 in set(adm2["a1_k"]) | set(official2["a1_k"]) if is_clean(a1)}
 )
-print(f"adm2 polygons joined: {len(adm2_joined)} / 168")
+dropped_a1 = sorted(
+    {a1 for a1 in set(adm2["a1_k"]) | set(official2["a1_k"]) if not is_clean(a1)}
+)
+print(f"clean admin1s ({len(clean_a1)}/16):  {clean_a1}")
+print(f"dropped admin1s ({len(dropped_a1)}/16): {dropped_a1}")
 ```
 
 ```{python}
-if str(adm2_joined.crs) != str(da.rio.crs):
-    adm2_joined = adm2_joined.to_crs(da.rio.crs)
+adm2_clean = adm2[adm2["a1_k"].isin(clean_a1)].merge(
+    official2.loc[official2["a1_k"].isin(clean_a1), ["a1_k", "a2_k", "pop_official"]],
+    on=["a1_k", "a2_k"],
+    validate="one_to_one",
+)
+if str(adm2_clean.crs) != str(da.rio.crs):
+    adm2_clean = adm2_clean.to_crs(da.rio.crs)
 
 stats2 = exact_extract(
     da,
-    adm2_joined,
+    adm2_clean,
     ops=["sum"],
     output="pandas",
     include_cols=["ADM2_PCODE", "ADM2_ES", "ADM1_ES", "pop_official"],
@@ -292,11 +300,14 @@ sum2_col = next(
     c for c in stats2.columns if c == "sum" or c.endswith("_sum")
 )
 stats2 = stats2.rename(columns={sum2_col: "pop_worldpop2026"})
-stats2["pct_diff"] = 100 * (stats2["pop_worldpop2026"] / stats2["pop_official"] - 1)
+stats2["pct_diff"] = (
+    100 * (stats2["pop_worldpop2026"] / stats2["pop_official"] - 1)
+)
 
+print(f"adm2 polygons in clean subset: {len(stats2)} / 168")
 print(
-    f"WP total: {stats2['pop_worldpop2026'].sum():>12,.0f}   "
-    f"ONEI total: {stats2['pop_official'].sum():>12,.0f}   "
+    f"WP total: {stats2['pop_worldpop2026'].sum():>11,.0f}   "
+    f"ONEI total: {stats2['pop_official'].sum():>11,.0f}   "
     f"diff: {100*(stats2['pop_worldpop2026'].sum()/stats2['pop_official'].sum()-1):+.2f}%"
 )
 r2 = np.corrcoef(stats2["pop_worldpop2026"], stats2["pop_official"])[0, 1]
@@ -307,56 +318,110 @@ print(f"Pearson r:    {r2:.4f}   (vs 0.997 at adm1)")
 print(f"Spearman rho: {rho2:.4f}   (vs 0.991 at adm1)")
 ```
 
-The national total agrees with the adm1 zonal sum to within ~0.1% (the
-small difference is just CODAB adm2 vs. Field Maps adm1 polygon edge
-effects). But the per-municipio agreement is **much worse**: Pearson r
-drops from 0.997 (adm1) to 0.87 (adm2), and per-unit `pct_diff` ranges
-from −90% to +414%. The deviations are not noise — they concentrate in
-specific places.
+After filtering, **9 of 16 admin1s qualify**, leaving 89 municipios. A
+naive Pearson r is 0.98, but that statistic is dominated by the largest
+municipios (each province's capital) and hides what is happening to the
+small ones. The more honest test is whether the per-adm2 `pct_diff`
+distribution *within each clean province* clusters tightly around that
+province's adm1-level `pct_diff` (which we already know — it sits on the
++11.3% rescale plus the east-west reshape).
 
 ```{python}
-top = stats2.nlargest(5, "pct_diff")[
-    ["ADM2_ES", "ADM1_ES", "pop_worldpop2026", "pop_official", "pct_diff"]
+adm1_summary = (
+    stats2.groupby("ADM1_ES")
+    .agg(
+        adm1_wp=("pop_worldpop2026", "sum"),
+        adm1_onei=("pop_official", "sum"),
+        n_adm2=("pop_worldpop2026", "size"),
+    )
+    .assign(adm1_pct=lambda d: 100 * (d["adm1_wp"] / d["adm1_onei"] - 1))
+)
+adm2_dist = stats2.groupby("ADM1_ES")["pct_diff"].agg(
+    ["min", "median", "max", "std"]
+)
+combined = (
+    adm1_summary.join(adm2_dist)
+    .sort_values("adm1_pct")[
+        ["n_adm2", "adm1_pct", "min", "median", "max", "std"]
+    ]
+    .round(1)
+)
+combined.columns = [
+    "n_adm2",
+    "adm1_pct",
+    "adm2_min",
+    "adm2_median",
+    "adm2_max",
+    "adm2_std",
 ]
-bot = stats2.nsmallest(5, "pct_diff")[
-    ["ADM2_ES", "ADM1_ES", "pop_worldpop2026", "pop_official", "pct_diff"]
-]
-print("=== Largest positive deviations (WP > ONEI) ===")
-print(top.round(0).to_string(index=False))
-print("=== Largest negative deviations (WP < ONEI) ===")
-print(bot.round(0).to_string(index=False))
+combined
 ```
 
-The pattern is striking: large positive *and* large negative deviations
-cluster inside **La Habana** province, often in adjacent municipios. Cerro
-shows +111% while neighbouring Arroyo Naranjo shows −87%. The two
-WorldPop estimates *do* sum back to roughly the ONEI provincial total —
-WorldPop just allocates the people across the urban core differently than
-ONEI's municipal census rows.
+Two things to notice:
 
-**Why the adm1 result does not extend to adm2.** Two compounding causes:
+1. **The median per-adm2 `pct_diff` closely tracks the adm1 `pct_diff`**
+   in each province (e.g. Mayabeque adm1 = +13.6%, adm2 median = +13.7%;
+   Sancti Spíritus adm1 = +11.3%, adm2 median = +11.4%). There is no
+   systematic within-province bias — the per-province mass is in roughly
+   the right place.
+2. **But the spread is large.** Villa Clara's individual municipios range
+   from −66% to +93% (std 37 pp); Pinar del Río and Artemisa span
+   ~80 pp; Matanzas and Mayabeque ~50–60 pp. Even in the cleanest
+   provinces, per-municipio agreement is far worse than per-province.
 
-1. **WorldPop's input admin level is not CODAB's published 168.** The
-   Release Statement says WorldPop "nested" Cuba's units from 168 down to
-   161 for harmonisation between its 2012 and 2022 timepoints (a
-   pre-processing step to keep boundaries consistent across census
-   rounds). The dasymetric mathematical preservation only holds at *that*
-   nested input level — not at CODAB's published level. Extracting by
-   CODAB's 168 polygons cuts through several of WorldPop's merged input
-   units, and within each merged unit population is spread by the
-   random-forest density + built-settlement mask, not by ONEI's municipal
-   boundaries.
-2. **The raster is 1km, the municipios are small.** Habana's 15 municipios
-   range from ~14 km² (Centro Habana, Cerro) to ~250 km² (La Habana del
-   Este). At 1km resolution, the small dense ones span only ~14 pixels —
-   not nearly enough for the dasymetric allocation across a merged input
-   unit to recover ONEI's municipio counts.
+This is consistent with the dasymetric preservation property of
+`popRF`: it preserves the *total* inside each WorldPop-input admin unit
+but redistributes population within that unit according to the random
+forest density × built-settlement mask. When CODAB's adm2 polygons
+happen to match WorldPop's internal nested adm2 boundaries, the
+per-municipio sums recover ONEI's values. When they don't, the within-
+unit allocation determines the per-CODAB-adm2 result, and that
+allocation depends on RF/settlement signal rather than on the actual
+ONEI municipal census.
 
-The shared-lineage logic does not break, then — it just becomes a
-constraint *on WorldPop's internal nested admin units*, not on every admin
-level a user might choose. At admin1, where many municipios aggregate
-together, the within-unit allocation noise averages out, and we see r =
-0.997. At admin2, that averaging is gone.
+To make the within-province scatter explicit, the **residual** of each
+adm2's `pct_diff` from its province's `pct_diff` should be centred near
+zero with most weight inside ±10–15 pp if dasymetric preservation
+behaved cleanly. In practice the residuals reach ±80 pp:
+
+```{python}
+stats2 = stats2.merge(
+    adm1_summary["adm1_pct"].rename("province_pct"),
+    left_on="ADM1_ES",
+    right_index=True,
+)
+stats2["residual_pp"] = stats2["pct_diff"] - stats2["province_pct"]
+print("=== Top 5 residuals (WP allocates more than its province average) ===")
+print(
+    stats2.nlargest(5, "residual_pp")[
+        ["ADM2_ES", "ADM1_ES", "pop_worldpop2026", "pop_official", "residual_pp"]
+    ]
+    .round(0)
+    .to_string(index=False)
+)
+print("=== Bottom 5 residuals (WP allocates less than its province average) ===")
+print(
+    stats2.nsmallest(5, "residual_pp")[
+        ["ADM2_ES", "ADM1_ES", "pop_worldpop2026", "pop_official", "residual_pp"]
+    ]
+    .round(0)
+    .to_string(index=False)
+)
+```
+
+So even after the strict admin1 filter:
+
+- **Province-level totals (adm1) are preserved.** Per-adm2 medians track
+  per-adm1 `pct_diff` closely, so there is no systematic within-province
+  bias.
+- **Individual municipio counts are not reliable.** The within-province
+  spread is ±20–80 pp. The raster is a province-level estimator, not a
+  municipio-level one — even in provinces where names and boundaries
+  align cleanly.
+- **The 7 dropped provinces include exactly the densest urban areas**
+  (La Habana, Santiago de Cuba, Cienfuegos). We can say nothing
+  empirically validated about adm2 accuracy there; a polygon-level
+  ONEI–CODAB crosswalk would be needed for a true test.
 
 ### Methodology context
 
@@ -400,13 +465,18 @@ is marked as an **alpha** release by WorldPop, with refinements expected.
   ranks match exactly, all 16 shares match within 1.1 pp, and r ≈ 0.997.
   Exposure rankings used for provincial prioritisation are insensitive to
   the choice between WorldPop and ONEI.
-- **At admin2, the raster is not a reliable per-municipio estimator.**
-  Pearson r drops to 0.87, with per-municipio deviations of −90% to
-  +414% concentrated in dense urban Habana. The dasymetric preservation
-  property holds only at WorldPop's internal nested input units (~161
-  for Cuba), not at CODAB's published 168. For municipio-level exposure
-  numbers, use ONEI's adm2 directly rather than zonal sums from this
-  raster.
+- **At admin2, the raster is not a reliable per-municipio estimator —
+  not even in provinces where names and boundaries align cleanly.**
+  After restricting to the 9 admin1s with perfect adm2-name matches
+  between CODAB and ONEI (89 municipios), the per-adm2 `pct_diff`
+  *median* tracks each province's adm1 `pct_diff` closely, but the
+  *spread* is ±20–80 percentage points within province. The
+  dasymetric preservation property holds only at WorldPop's internal
+  nested input units (~161 for Cuba), not at CODAB's published 168 —
+  so within-province allocation is driven by the random-forest density
+  + built-settlement mask, not by ONEI's municipal census. For
+  municipio-level exposure numbers, use ONEI's adm2 directly rather
+  than zonal sums from this raster.
 - **Absolute counts are not robust at any level.** Both datasets descend
   from the 2012 census via ONEI projections that do not reflect post-2020
   emigration. Independent estimates suggest the true end-2024 population

--- a/book_cub_hurricanes/appendix_population_data.qmd
+++ b/book_cub_hurricanes/appendix_population_data.qmd
@@ -1,0 +1,275 @@
+---
+jupyter: ds-aa-cub-hurricanes
+---
+
+## Appendix 1B: Population Data Validation — WorldPop vs. ONEI
+
+The trigger framework uses gridded population to estimate exposure inside the
+ZMA. Before relying on those exposure numbers, this appendix sanity-checks the
+WorldPop raster we use against an independent official tabulation from ONEI
+(Oficina Nacional de Estadística e Información de Cuba). The two are not fully
+independent — both descend from Cuba's 2012 census — but the comparison still
+diagnoses (i) whether province-level totals are coherent across products, (ii)
+where they disagree, and (iii) the order of magnitude of structural uncertainty
+on absolute counts.
+
+### Inputs
+
+| Role          | Source                                                                                                                                                                                                                    |
+|---------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| Polygons      | Field Maps edge-matched humanitarian admin1 (`fieldmaps/edge-matched/humanitarian/intl/adm1/CUB.parquet`, Blob container `global`)                                                                                         |
+| Raster        | WorldPop Global 2 R2025A, 2026, **constrained**, 1km (`worldpop/pop_count/global_pop_2026_CN_1km_R2025A_UA_v1.tif`, Blob container `raster`)                                                                                |
+| Official ref. | ONEI 2025 projection (end-2024), 16 provinces, Blob container `projects` at `{PROJECT_PREFIX}/raw/unfpa/CUB_ADM1_POP_2024.xlsx`, sheet `CUB_ADM1_POP_2024`, column `T_TL`                                                          |
+
+The xlsx is published via ONEI's *Observatorio de Igualdad de Género*. Despite
+the "2024" filename, rows are tagged `year = 2025` (this is the 2025-published
+projection for the 2024 reference year).
+
+### Zonal sums
+
+```{python}
+import io
+import unicodedata
+
+import geopandas as gpd
+import numpy as np
+import ocha_stratus as stratus
+import pandas as pd
+from exactextract import exact_extract
+
+from src.constants import PROJECT_PREFIX
+
+
+def norm_name(s: str) -> str:
+    """Accent-fold + lowercase for joining province names across sources."""
+    return (
+        unicodedata.normalize("NFKD", str(s))
+        .encode("ascii", "ignore")
+        .decode("ascii")
+        .strip()
+        .lower()
+    )
+
+
+adm1_raw = stratus.load_blob_data(
+    "fieldmaps/edge-matched/humanitarian/intl/adm1/CUB.parquet",
+    container_name="global",
+    stage="dev",
+)
+adm1 = gpd.read_parquet(io.BytesIO(adm1_raw))
+
+da = stratus.open_blob_cog(
+    "worldpop/pop_count/global_pop_2026_CN_1km_R2025A_UA_v1.tif",
+    container_name="raster",
+    stage="dev",
+)
+if "band" in da.dims and da.sizes.get("band", 1) == 1:
+    da = da.squeeze("band", drop=True)
+
+if str(adm1.crs) != str(da.rio.crs):
+    adm1 = adm1.to_crs(da.rio.crs)
+
+# exactextract handles partial-pixel coverage; sum is area-weighted
+stats = exact_extract(
+    da, adm1, ops=["sum"], output="pandas", include_cols=["adm1_name"]
+)
+sum_col = next(
+    c for c in stats.columns if c == "sum" or c.endswith("_sum")
+)
+stats = stats.rename(columns={sum_col: "pop_worldpop2026"})
+stats["name_key"] = stats["adm1_name"].map(norm_name)
+```
+
+```{python}
+xlsx_blob = f"{PROJECT_PREFIX}/raw/unfpa/CUB_ADM1_POP_2024.xlsx"
+xlsx_bytes = stratus.load_blob_data(
+    xlsx_blob, container_name="projects", stage="dev"
+)
+official = pd.read_excel(
+    io.BytesIO(xlsx_bytes), sheet_name="CUB_ADM1_POP_2024"
+)
+official = (
+    official[["ADM1_PCODE", "ADM1_NAME", "T_TL"]]
+    .rename(columns={"T_TL": "pop_official"})
+    .assign(name_key=lambda d: d["ADM1_NAME"].map(norm_name))
+)
+
+merged = (
+    stats.merge(official, on="name_key", validate="one_to_one")
+    .sort_values("ADM1_PCODE")
+    .reset_index(drop=True)
+)
+merged["diff"] = merged["pop_worldpop2026"] - merged["pop_official"]
+merged["pct_diff"] = 100 * merged["diff"] / merged["pop_official"]
+merged[
+    ["ADM1_PCODE", "adm1_name", "pop_worldpop2026", "pop_official", "diff", "pct_diff"]
+].round(0)
+```
+
+Admin0 (Cuba) aggregates:
+
+```{python}
+total_wp = merged["pop_worldpop2026"].sum()
+total_off = merged["pop_official"].sum()
+print(f"WorldPop 2026 (constrained, sum of adm1): {total_wp:>12,.0f}")
+print(f"ONEI 2024 projection (sum of adm1):      {total_off:>12,.0f}")
+print(f"Difference: {total_wp - total_off:>+,.0f} ({100*(total_wp/total_off - 1):+.2f}%)")
+```
+
+### Same shape, different totals
+
+The +11% national gap could mean either (a) the two datasets disagree on the
+spatial distribution of people across provinces, or (b) the spatial
+distribution is similar and only the national total differs. To tell them
+apart, compare each province's *share* of the national total in both datasets.
+
+```{python}
+share = merged.assign(
+    wp_share=lambda d: 100 * d["pop_worldpop2026"] / d["pop_worldpop2026"].sum(),
+    onei_share=lambda d: 100 * d["pop_official"] / d["pop_official"].sum(),
+)
+share["share_diff_pp"] = share["wp_share"] - share["onei_share"]
+share[["ADM1_PCODE", "adm1_name", "wp_share", "onei_share", "share_diff_pp"]].round(2)
+```
+
+Shares match within ~1 percentage point across all 16 provinces. The
+Pearson correlation between provincial totals is essentially 1:
+
+```{python}
+r = np.corrcoef(merged["pop_worldpop2026"], merged["pop_official"])[0, 1]
+print(f"Pearson r (admin1 totals): {r:.4f}")
+```
+
+### Decomposing the per-province difference
+
+Per-province `pct_diff` ranges from +4% (Guantánamo) to +18% (La Habana).
+That is not the +11.3% you would get from a pure national rescale. Both
+components matter and they compose multiplicatively:
+
+$$\text{WP}_i = \text{ONEI}_i \times \underbrace{\frac{\sum \text{WP}}{\sum \text{ONEI}}}_{\text{rescale}} \times \underbrace{\frac{s^{\text{WP}}_i}{s^{\text{ONEI}}_i}}_{\text{reshape}}$$
+
+where $s_i$ is province $i$'s share of the national total.
+
+```{python}
+rescale = total_wp / total_off
+decomp = merged.assign(
+    total_pct=lambda d: 100 * (d["pop_worldpop2026"] / d["pop_official"] - 1),
+    rescale_pct=100 * (rescale - 1),
+    reshape_pct=lambda d: 100
+    * (
+        (d["pop_worldpop2026"] / total_wp)
+        / (d["pop_official"] / total_off)
+        - 1
+    ),
+)
+decomp[
+    ["ADM1_PCODE", "adm1_name", "total_pct", "rescale_pct", "reshape_pct"]
+].round(2)
+```
+
+The rescale is +11.3% for every province (UN WPP 2024 national total vs.
+ONEI's 2025 internal projection). The reshape varies from −6.6% (Guantánamo)
+to +6.0% (La Habana), with a clear east–west tilt:
+
+| Direction         | Provinces (reshape sign)                                                |
+|-------------------|-------------------------------------------------------------------------|
+| Western (gainers) | La Habana, Artemisa, Cienfuegos, Camagüey, Mayabeque, Villa Clara        |
+| Eastern (losers)  | Guantánamo, Granma, Santiago de Cuba, Holguín, Las Tunas                 |
+
+### Rank check
+
+For applications that rank provinces by exposure, the question is whether the
+ordering is preserved. 13 of 16 provinces have identical rank between
+WorldPop and ONEI; the three that swap are a single trio in the middle of
+the distribution:
+
+```{python}
+ranked = merged.assign(
+    rank_wp=lambda d: d["pop_worldpop2026"].rank(ascending=False, method="min").astype(int),
+    rank_onei=lambda d: d["pop_official"].rank(ascending=False, method="min").astype(int),
+)
+ranked["rank_diff"] = ranked["rank_wp"] - ranked["rank_onei"]
+ranked.sort_values("rank_onei")[
+    ["adm1_name", "rank_wp", "rank_onei", "rank_diff"]
+]
+```
+
+Spearman ρ on admin1 totals:
+
+```{python}
+r_wp = merged["pop_worldpop2026"].rank()
+r_on = merged["pop_official"].rank()
+rho = np.corrcoef(r_wp, r_on)[0, 1]
+print(f"Spearman rho: {rho:.4f}")
+```
+
+The only meaningful rank swap is Artemisa rising 2 places (9th → 11th in
+ONEI, but 9th in WorldPop), pushing Las Tunas and Guantánamo down one slot
+each. That is the same east-west reshape made visible on the rank scale.
+
+### Methodology context
+
+**ONEI projection.** The xlsx is ONEI's projection from the 2012 *Censo de
+Población y Viviendas* (Cuba's last completed census) using a deterministic
+cohort-component method via CEPDE under a UNFPA collaboration. The xlsx's
+"Methods" cell does not specify the technique explicitly. The known
+methodological weakness, documented by independent demographers (notably
+Albizu-Campos, CEDEM/UH), is in emigration accounting:
+
+- Since 2013, ONEI does not classify as emigrants persons who hold a valid
+  Cuban passport and re-enter the country at least once every 24 months,
+  regardless of where they actually live.
+- The external migration balance is reportedly dominated by US arrivals data,
+  undercounting flows to Spain, Mexico, Russia, Uruguay, etc.
+- Independent reconstruction from electoral rolls + birth/death + destination
+  data places end-2024 population at roughly 8.0M vs. ONEI's 9.75M — a
+  ~1.7M (~18%) gap that ONEI's published projection does not see.
+
+**WorldPop pipeline.** The R2025A raster is produced by random-forest
+dasymetric disaggregation (Stevens et al. 2007), implemented via the
+`popRF` R package. For Cuba specifically (WorldPop's census-sources sheet,
+row 52):
+
+| Stage      | Input for Cuba                                                                                                |
+|------------|---------------------------------------------------------------------------------------------------------------|
+| Timepoint 1 | ONEI 2012 census, 168 municipios                                                                              |
+| Timepoint 2 | ONEI *Anuario Estadístico 2022*, 170 municipios                                                              |
+| Annual interpolation | Modelled per municipio, 2010–2030                                                                  |
+| National constraint | UN WPP 2024 Revision, January-1st estimates                                                         |
+| Settlement mask | GHSL BUILT-S/V + Google Open Buildings v3 + Microsoft Building Footprints + World Settlement Footprint    |
+
+Both WorldPop timepoints are ONEI products, and the UN WPP 2024 national
+control itself draws on ONEI. So WorldPop and our reference xlsx share the
+same 2012-census-rooted lineage and the same emigration blind-spot. R2025A
+is marked as an **alpha** release by WorldPop, with refinements expected.
+
+### What this means for the trigger framework
+
+- **Rank- or share-based comparisons across provinces are robust.** 13/16
+  ranks match exactly, all 16 shares match within 1.1 pp, and the
+  province-correlation is r ≈ 0.997. Exposure rankings used for
+  prioritisation are unaffected by the choice of dataset.
+- **Absolute counts are not robust.** Both datasets descend from the 2012
+  census via ONEI projections that do not reflect post-2020 emigration.
+  Independent estimates suggest the true end-2024 population is ~15–18%
+  lower than either number. If absolute "people affected" figures are
+  needed, they should be flagged with that uncertainty.
+- **The +11% gap between WorldPop and the xlsx is not evidence about real
+  population.** It is mostly a difference between UN WPP 2024 (WorldPop's
+  national control) and ONEI's later 2025 projection (the xlsx). The
+  ~6% east-west reshape on top is consistent with WorldPop's 2022 input
+  pre-dating ONEI's 2025 redistribution of share away from eastern Cuba.
+
+### References
+
+- WorldPop. *Global Demographic Data: Public Release R2025A V1*, September
+  2025. <https://data.worldpop.org/repo/prj/Global_2015_2030/R2025A/doc/Global2_Release_Statement_R2025A_v1.pdf>
+- WorldPop. *Census data sources, R2025A v1* (Cuba: row 52). <https://data.worldpop.org/repo/prj/Global_2015_2030/R2025A/doc/census/global2_census_data_sources_R2025A_v1.xlsx>
+- Stevens, F. R., Gaughan, A. E., Linard, C. & Tatem, A. J. (2015).
+  Disaggregating census data for population mapping using random forests
+  with remotely-sensed and ancillary data. *PLoS ONE* 10:e0107042.
+- UN DESA, Population Division (2024). *World Population Prospects 2024:
+  Methodology*. UN DESA/POP/2024/DC/NO.10.
+- ONEI (2025). *Cuba: 9,748,007 habitantes al cierre de 2024*. <http://www.onei.gob.cu/node/2586>
+- Albizu-Campos critique (summarised in Columbia Horizonte Cubano, 2025).
+  <https://horizontecubano.law.columbia.edu/news/cuba-una-rapida-mirada-la-emigracion-y-la-poblacion>

--- a/book_cub_hurricanes/zma.qmd
+++ b/book_cub_hurricanes/zma.qmd
@@ -1,9 +1,24 @@
 ---
 title: ZMA
+jupyter: ds-aa-cub-hurricanes
 ---
 
 
 <!-- markdownlint-disable MD013 -->
 Showing the Zona de Máxima Atención, based on the map (dotted red line):
 
-![](cub_zma.png)
+```{python}
+#| echo: false
+import ocha_stratus as stratus
+from IPython.display import Image
+from src.constants import PROJECT_PREFIX
+
+# Static book images live in blob (projects/<PROJECT_PREFIX>/book_static); the local
+# book PNGs are gitignored, so blob is the reproducible source for any build.
+png_bytes = stratus.load_blob_data(
+    f"{PROJECT_PREFIX}/book_static/cub_zma.png",
+    container_name="projects",
+    stage="dev",
+)
+Image(data=png_bytes)
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,9 @@ Jinja2==3.1.6
 ocha-stratus==0.1.2
 tqdm==4.67.1
 ipywidgets==8.1.7
+# Zonal stats + Excel I/O for appendix_population_data
+exactextract>=0.3.0
+openpyxl>=3.1.5
 # Jupyter dependencies required by Quarto
 jupyter>=1.0.0
 nbclient>=0.8.0

--- a/scripts/methodology_map.py
+++ b/scripts/methodology_map.py
@@ -1,0 +1,273 @@
+"""Methodology illustration map for the Cuba hurricane AA presentation.
+
+Overlays IBTrACS wind-radii buffers (34 / 50 / 64 kt) for a selected storm on top
+of the WorldPop population-count raster, clipped to Cuba. Produces a single PNG that
+shows, at a glance, how the trigger methodology combines a storm's wind footprint with
+where people actually live.
+
+This is a STANDALONE script. It does not modify any existing project code. It only
+reads from the same sources the pipeline already uses:
+  - storms.ibtracs_wind_buffers   (PostGIS, via ocha_stratus.get_engine)
+  - WorldPop population COG        (via ocha_stratus.open_blob_cog)
+  - CODAB admin boundaries         (via src.datasources.codab)
+
+Usage:
+    python scripts/methodology_map.py                 # default storm (Ian 2022)
+    python scripts/methodology_map.py ike             # by friendly name
+    python scripts/methodology_map.py 2008245N17323   # by raw IBTrACS SID
+    python scripts/methodology_map.py oscar --coarsen 3 --out docs/oscar.png
+    python scripts/methodology_map.py melissa --upload  # also push PNG to blob
+
+Notes:
+  - The population raster is windowed to Cuba's bounding box (padded) before reading,
+    so we never pull the full global grid.
+  - --coarsen N downsamples the raster by NxN, summing population (each coarse cell =
+    total people in it). Higher N = coarser/lower-resolution map.
+  - --upload pushes the PNG to blob (projects/<BLOB_DIR>) so the Quarto book can load
+    it at render time; the book's static images are gitignored so blob is the source.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import geopandas as gpd
+import matplotlib.pyplot as plt
+import ocha_stratus as stratus
+from matplotlib.colors import AsinhNorm, Normalize
+from matplotlib.lines import Line2D
+from sqlalchemy import text
+
+# Put the repo root on the path so `src` imports resolve when this script is run
+# directly (python scripts/methodology_map.py). The pipelines/ scripts instead rely
+# on PYTHONPATH=<repo root>, which is set for them in the GitHub workflows.
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+from src.constants import GUSTAV, IAN, IKE, IRMA, OSCAR, PROJECT_PREFIX  # noqa: E402
+from src.datasources import codab  # noqa: E402
+from src.utils.blob_utils import _upload_blob_data  # noqa: E402
+
+# Friendly storm names -> IBTrACS SIDs. Most come from src/constants.py; Melissa 2025
+# is not in constants yet, so it's defined here (resolved from the storms table).
+MELISSA = "2025291N11319"
+STORMS = {
+    "ike": IKE,
+    "gustav": GUSTAV,
+    "irma": IRMA,
+    "ian": IAN,
+    "oscar": OSCAR,
+    "melissa": MELISSA,
+}
+
+POP_BLOB = "worldpop/pop_count/global_pop_2026_CN_1km_R2025A_UA_v1.tif"
+# Where --upload puts the PNG so the Quarto book can load it (container=projects).
+BLOB_DIR = f"{PROJECT_PREFIX}/book_static"
+WIND_SPEEDS = [34, 50, 64]  # knots; 34 is the widest buffer, 64 the tightest core
+
+# Match the marimo storm-selector styling: YlOrRd ramp normalised 20-80 kt.
+_CMAP = plt.get_cmap("YlOrRd")
+_NORM = Normalize(vmin=20, vmax=80)
+
+
+def resolve_sid(storm: str) -> str:
+    """Accept either a friendly name (ike, ian, ...) or a raw IBTrACS SID."""
+    key = storm.lower().strip()
+    if key in STORMS:
+        return STORMS[key]
+    # Looks like a raw SID (e.g. 2008245N17323) -- pass it straight through.
+    return storm
+
+
+def load_buffers(sid: str) -> gpd.GeoDataFrame:
+    """Wind-radii buffer polygons for one storm, from the PostGIS table."""
+    engine = stratus.get_engine("dev")
+    gdf = gpd.read_postgis(
+        text(
+            "SELECT sid, wind_speed_kt, geometry"
+            " FROM storms.ibtracs_wind_buffers"
+            " WHERE sid = :sid"
+        ),
+        engine,
+        geom_col="geometry",
+        params={"sid": sid},
+    )
+    if gdf.empty:
+        raise SystemExit(
+            f"No wind buffers found for sid={sid!r}. "
+            f"Known names: {', '.join(STORMS)}."
+        )
+    if gdf.crs is None:
+        gdf = gdf.set_crs(4326)
+    return gdf.to_crs(4326)
+
+
+def storm_label(sid: str) -> str:
+    """A human title like 'Ian (2022)' if the metadata table has it."""
+    try:
+        engine = stratus.get_engine("dev")
+        with engine.connect() as con:
+            row = con.execute(
+                text(
+                    "SELECT name, season FROM storms.ibtracs_storms"
+                    " WHERE sid = :sid"
+                ),
+                {"sid": sid},
+            ).fetchone()
+        if row and row[0]:
+            name = str(row[0]).title()
+            return f"{name} ({row[1]})" if row[1] else name
+    except Exception:
+        pass
+    return sid
+
+
+def load_population(bounds, coarsen: int, adm0: gpd.GeoDataFrame):
+    """Window the global WorldPop COG to `bounds`, coarsen, and clip to Cuba.
+
+    Returns a 2-D DataArray of people per coarse cell that is a CONTINUOUS surface
+    over land (empty land = 0, not NaN) with only the ocean masked out. Keeping land
+    hole-free is what lets bilinear interpolation render a smooth density surface
+    instead of scattered isolated squares.
+    """
+    minx, miny, maxx, maxy = bounds
+    da = stratus.open_blob_cog(POP_BLOB, container_name="raster", stage="dev")
+    da = da.rio.clip_box(minx, miny, maxx, maxy)  # windowed read only
+    da = da.squeeze("band", drop=True)
+    # Drop WorldPop's large-negative nodata BEFORE coarsening, or it would poison the
+    # per-cell sums. coarsen().sum() then skips NaN and sums only the valid pixels.
+    da = da.where(da >= 0)
+    if coarsen > 1:
+        da = da.coarsen(x=coarsen, y=coarsen, boundary="trim").sum()
+    # Fill the remaining NaN (empty land + ocean) with 0 so land has no holes, then
+    # clip to the coastline so only the ocean is masked back out (transparent).
+    da = da.fillna(0)
+    da = da.rio.clip(adm0.geometry, adm0.crs, all_touched=True, drop=False)
+    return da
+
+
+def make_map(sid: str, coarsen: int, pad: float, out: Path) -> Path:
+    adm0 = codab.load_codab_from_blob(admin_level=0)
+    adm1 = codab.load_codab_from_blob(admin_level=1)
+    buffers = load_buffers(sid)
+
+    # Plot window: the full bounding box of Cuba (padded), regardless of where the
+    # storm's buffers fall. Buffers that extend past the coast simply run off-frame.
+    minx, miny, maxx, maxy = adm0.total_bounds
+    extent = (minx - pad, miny - pad, maxx + pad, maxy + pad)
+
+    pop = load_population(extent, coarsen, adm0)
+
+    fig, ax = plt.subplots(figsize=(13, 6), dpi=200)
+
+    # Base layer: population on an asinh ("pseudo-log") scale -- linear through the
+    # sparse low-population land and log-like across the dense cities, so the whole
+    # dynamic range reads smoothly without a hard log floor. A magma ramp on a black
+    # face gives a "population density" glow: empty land dark, cities bright.
+    pop_cmap = plt.get_cmap("magma").copy()
+    ax.set_facecolor(pop_cmap(0.0))
+    # Cap at a high percentile, not the single max, so mid-size cities read bright
+    # instead of being washed out by the one most-populous cell (Havana). The linear
+    # width sets where asinh hands off from linear to log (roughly "village" scale).
+    populated = pop.where(pop > 0)
+    vmax = float(populated.quantile(0.99))
+    linear_width = max(vmax / 50, 10.0)
+    pop.plot.imshow(
+        ax=ax,
+        cmap=pop_cmap,
+        norm=AsinhNorm(linear_width=linear_width, vmin=0, vmax=vmax),
+        interpolation="gaussian",
+        add_colorbar=True,
+        cbar_kwargs={
+            "label": f"Population (people per {coarsen} km cell)",
+            "shrink": 0.7,
+            "pad": 0.02,
+        },
+        zorder=1,
+    )
+
+    # Context: admin boundaries (light, so they read over the dark raster).
+    adm1.boundary.plot(ax=ax, color="white", linewidth=0.3, alpha=0.35, zorder=2)
+    adm0.boundary.plot(ax=ax, color="white", linewidth=1.0, alpha=0.8, zorder=3)
+
+    # Overlay: wind buffers as bold rings with a very faint fill. The buffers are
+    # nested disks (34 kt contains 50 contains 64), so the low-alpha fills stack
+    # gently toward the core -- a subtle "more intense at the centre" wash -- while
+    # staying light enough that the population underneath stays clearly visible.
+    for wt in WIND_SPEEDS:
+        buf = buffers[
+            (buffers["wind_speed_kt"] == wt) & buffers.geometry.notna()
+        ]
+        if buf.empty:
+            continue
+        color = _CMAP(_NORM(wt))
+        buf.plot(ax=ax, facecolor=color, edgecolor="none", alpha=0.14, zorder=4)
+        buf.boundary.plot(ax=ax, color=color, linewidth=2.2, alpha=0.95, zorder=5)
+
+    legend_handles = [
+        Line2D([0], [0], color=_CMAP(_NORM(wt)), linewidth=2.2,
+               label=f"{wt} kt wind")
+        for wt in WIND_SPEEDS
+    ]
+    ax.legend(handles=legend_handles, loc="lower left", framealpha=0.9,
+              title="Wind footprint")
+
+    ax.set_xlim(extent[0], extent[2])
+    ax.set_ylim(extent[1], extent[3])
+    ax.set_aspect("equal")
+    ax.set_xlabel("")
+    ax.set_ylabel("")
+    ax.set_title(
+        f"Wind footprint over population — {storm_label(sid)}",
+        fontsize=13,
+    )
+
+    out.parent.mkdir(parents=True, exist_ok=True)
+    fig.savefig(out, bbox_inches="tight", dpi=200)
+    plt.close(fig)
+    return out
+
+
+def main():
+    p = argparse.ArgumentParser(description=__doc__)
+    p.add_argument(
+        "storm",
+        nargs="?",
+        default="ian",
+        help="Storm name (ike, gustav, irma, ian, oscar) or raw IBTrACS SID.",
+    )
+    p.add_argument(
+        "--coarsen", type=int, default=2,
+        help="Downsample factor for the raster (NxN, summed). Default 2.",
+    )
+    p.add_argument(
+        "--pad", type=float, default=0.5,
+        help="Degrees of padding around Cuba's bounding box. Default 0.5.",
+    )
+    p.add_argument(
+        "--out", type=Path, default=None,
+        help="Output PNG path. Default docs/methodology_map_<storm>.png",
+    )
+    p.add_argument(
+        "--upload", action="store_true",
+        help=f"Also upload the PNG to blob (projects/{BLOB_DIR}) for the book.",
+    )
+    args = p.parse_args()
+
+    sid = resolve_sid(args.storm)
+    out = args.out or Path("docs") / f"methodology_map_{args.storm.lower()}.png"
+    saved = make_map(sid, args.coarsen, args.pad, out)
+    print(f"Saved {saved}")
+
+    if args.upload:
+        blob_name = f"{BLOB_DIR}/{saved.name}"
+        _upload_blob_data(
+            saved.read_bytes(),
+            blob_name,
+            stage="dev",
+            container_name="projects",
+            content_type="image/png",
+        )
+        print(f"Uploaded to blob (container=projects, stage=dev): {blob_name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/datasources/ibtracs.py
+++ b/src/datasources/ibtracs.py
@@ -13,8 +13,10 @@ def load_ibtracs_in_bounds(min_lon, min_lat, max_lon, max_lat):
 
 
 def load_storms():
+    # storms.storms was renamed to storms.ibtracs_storms (sid, atcf_id, name,
+    # season, genesis_basin, ...).
     query = """
-    SELECT * FROM storms.storms
+    SELECT * FROM storms.ibtracs_storms
     """
     df = pd.read_sql(query, stratus.get_engine("dev"))
     return df


### PR DESCRIPTION
## Summary

Adds population-related documentation to the Quarto book, plus a new standalone map utility.

**Population data validation appendix** (`appendix_population_data.qmd`, prior commits on this branch)
- Validates the WorldPop 2026 raster against ONEI 2024 official figures by adm1.
- Extends the cross-check to adm2 zonal stats, restricted to provinces with clean name alignment.

**Wind-footprint-over-population methodology map** (this work)
- `scripts/methodology_map.py`: standalone script that overlays IBTrACS wind buffers (34/50/64 kt) for a selected storm on the WorldPop population raster, clipped to Cuba and rendered on an asinh ("pseudo-log") colour scale. Renders any storm by name (`ike`/`gustav`/`irma`/`ian`/`oscar`/`melissa`) or raw SID; `--upload` pushes the PNG to blob (`projects/ds-aa-cub-hurricanes/book_static`).
- `appendix_methodology_map.qmd`: new appendix that loads the Melissa (2025) figure from blob and includes the script source as a static code listing.
- `zma.qmd`: now loads `cub_zma.png` from blob as well — book PNGs are gitignored, so blob is the reproducible source for any build.
- `_quarto.yml`: registers the new appendix.

## Notes
- Static book images are stored in blob (`projects/ds-aa-cub-hurricanes/book_static/`) rather than committed, since `book_cub_hurricanes/**/*.png` is gitignored.
- Both new/changed chapters were verified to render locally (`quarto render`), pulling their images from blob.