### PR TITLE
Source 2026 monitoring from dev DB and partition blobs by season

### DIFF
--- a/src/constants.py
+++ b/src/constants.py
@@ -1,7 +1,8 @@
-import numpy as np
 import os
-import pytz
 from datetime import datetime, timezone
+
+import numpy as np
+import pytz
 
 PROJECT_PREFIX = "ds-aa-cub-hurricanes"
 ISO3 = "cub"
@@ -12,6 +13,16 @@ cuba_tz = pytz.timezone("America/Havana")
 MONITORING_START_DATE = cuba_tz.localize(datetime(2025, 1, 1)).astimezone(
     timezone.utc
 )
+
+
+def current_monitoring_season() -> int:
+    """Current Atlantic monitoring season as a calendar year.
+
+    Atlantic hurricane seasons fall within a single year (Jun-Nov), so the
+    season is just the current year. Used to scope NHC track loads and to
+    partition the monitoring/plot blobs by year (monitoring/{year}/...).
+    """
+    return datetime.now().year
 
 
 # Runtime control flags - centralized configuration

--- a/src/datasources/nhc.py
+++ b/src/datasources/nhc.py
@@ -2,13 +2,15 @@ import gzip
 from datetime import datetime
 from ftplib import FTP
 from io import BytesIO
+from typing import Optional
 
 import geopandas as gpd
 import ocha_stratus as stratus
 import pandas as pd
+from sqlalchemy import text
 from tqdm.auto import tqdm
 
-from src.constants import PROJECT_PREFIX
+from src.constants import PROJECT_PREFIX, current_monitoring_season
 
 
 def download_historical_forecasts(
@@ -164,39 +166,124 @@ def load_historical_forecasts(include_geometry: bool = False):
         return df
 
 
-def load_recent_glb_nhc(fcast_obsv: str = "fcast"):
+# Atlantic NHC tracks now come from the dev database instead of the rolling
+# global CSV snapshot (noaa/nhc/{forecasted,observed}_tracks.csv). The track
+# geometries live in storms.nhc_tracks_geo and storm names in
+# storms.nhc_storms. Because the DB is the full 1990-onward archive (the CSV
+# only ever held recent storms), the loaders scope to a single Atlantic season;
+# otherwise the monitor would reprocess decades of history into the monitoring
+# parquet.
+NHC_TRACKS_TABLE = "storms.nhc_tracks_geo"
+NHC_STORMS_TABLE = "storms.nhc_storms"
+
+
+def _as_utc(series: pd.Series) -> pd.Series:
+    """NHC times are UTC; the DB stores them tz-naive. Return tz-aware UTC so
+    the output matches the old CSV (downstream code calls .astimezone / splits
+    the isoformat offset and needs aware timestamps)."""
+    series = pd.to_datetime(series)
+    if series.dt.tz is None:
+        return series.dt.tz_localize("UTC")
+    return series.dt.tz_convert("UTC")
+
+
+def _load_nhc_tracks_from_db(
+    select_cols: str, leadtime_clause: str, season: int
+) -> pd.DataFrame:
+    """Query one Atlantic season of NHC tracks, joined to storm names.
+
+    `select_cols` and `leadtime_clause` are fixed internal SQL fragments (not
+    user input); `season` is bound as a parameter.
+    """
+    # Plain .format() (not an f-string) so the SQLAlchemy ":season" bind param
+    # isn't tokenised as code by the linter under Python 3.12.
+    query = text(
+        """
+        SELECT {select_cols}
+        FROM {tracks} t
+        JOIN {storms} s ON s.atcf_id = t.atcf_id
+        WHERE s.genesis_basin = 'NA'
+          AND s.season = :season
+          AND {leadtime_clause}
+        """.format(
+            select_cols=select_cols,
+            tracks=NHC_TRACKS_TABLE,
+            storms=NHC_STORMS_TABLE,
+            leadtime_clause=leadtime_clause,
+        )
+    )
+    return pd.read_sql(
+        query, stratus.get_engine("dev"), params={"season": season}
+    )
+
+
+def load_recent_glb_nhc(
+    fcast_obsv: str = "fcast", season: Optional[int] = None
+):
     """
     Load the most recent NHC forecast or observed tracks.
 
     Parameters:
     fcast_obsv (str): "fcast" for forecasts, "obsv" for observations.
+    season (int): Atlantic season (year) to load. Defaults to current year.
 
     Returns:
     pd.DataFrame: DataFrame containing the tracks.
     """
     if fcast_obsv == "fcast":
-        return load_recent_glb_forecasts()
+        return load_recent_glb_forecasts(season=season)
     elif fcast_obsv == "obsv":
-        return load_recent_glb_obsv()
+        return load_recent_glb_obsv(season=season)
     else:
         raise ValueError("fcast_obsv must be 'fcast' or 'obsv'")
 
 
-def load_recent_glb_forecasts():
-    return stratus.load_csv_from_blob(
-        "noaa/nhc/forecasted_tracks.csv",
-        stage="dev",
-        container_name="global",
-        parse_dates=["issuance", "validTime"],
-        sep=";",
+def load_recent_glb_forecasts(season: Optional[int] = None) -> pd.DataFrame:
+    """Atlantic NHC forecast tracks for one season, from the dev database.
+
+    Returns the same columns/dtypes the old global CSV did so the monitor and
+    email code are unchanged: id (lowercase atcf), name, issuance, basin
+    ('al'), latitude, longitude, maxwind, validTime (tz-aware UTC). Forecast
+    points are the leadtime>0 rows of each issuance; the t=0 analysis point is
+    served by the observed feed, matching how the CSV split the two products.
+    """
+    season = season or current_monitoring_season()
+    select_cols = (
+        "lower(t.atcf_id) AS id, "
+        "s.name AS name, "
+        "t.issued_time AS issuance, "
+        "'al' AS basin, "
+        "ST_Y(t.geometry) AS latitude, "
+        "ST_X(t.geometry) AS longitude, "
+        "t.wind_speed AS maxwind, "
+        't.valid_time AS "validTime"'
     )
+    df = _load_nhc_tracks_from_db(select_cols, "t.leadtime > 0", season)
+    df["issuance"] = _as_utc(df["issuance"])
+    df["validTime"] = _as_utc(df["validTime"])
+    return df
 
 
-def load_recent_glb_obsv():
-    return stratus.load_csv_from_blob(
-        "noaa/nhc/observed_tracks.csv",
-        stage="dev",
-        container_name="global",
-        parse_dates=["lastUpdate"],
-        sep=";",
+def load_recent_glb_obsv(season: Optional[int] = None) -> pd.DataFrame:
+    """Atlantic NHC observed (analysis) tracks for one season, from the dev
+    database.
+
+    Returns the old global-CSV columns/dtypes: id (lowercase atcf), name,
+    basin ('al'), intensity, pressure, latitude, longitude, lastUpdate
+    (tz-aware UTC). Observed points are the leadtime=0 analysis rows (synoptic
+    6-hourly; pressure is not populated on these rows in the DB).
+    """
+    season = season or current_monitoring_season()
+    select_cols = (
+        "lower(t.atcf_id) AS id, "
+        "s.name AS name, "
+        "'al' AS basin, "
+        "t.wind_speed AS intensity, "
+        "t.pressure AS pressure, "
+        "ST_Y(t.geometry) AS latitude, "
+        "ST_X(t.geometry) AS longitude, "
+        't.valid_time AS "lastUpdate"'
     )
+    df = _load_nhc_tracks_from_db(select_cols, "t.leadtime = 0", season)
+    df["lastUpdate"] = _as_utc(df["lastUpdate"])
+    return df

--- a/src/email/plotting.py
+++ b/src/email/plotting.py
@@ -49,6 +49,7 @@ from src.constants import (
     PROJECT_PREFIX,
     SPANISH_MONTHS,
     THRESHS,
+    current_monitoring_season,
 )
 from src.datasources import codab, nhc, zma
 from src.email.utils import (
@@ -58,10 +59,25 @@ from src.email.utils import (
 )
 
 
+def _year_from_monitor_id(monitor_id: str) -> int:
+    """Partition year for a plot: the year in the monitor_id's issue timestamp
+    (``..._YYYY-MM-DDThh:mm:ss``). Falls back to the current season if the id
+    doesn't parse."""
+    try:
+        year = int(monitor_id.split("_")[-1][:4])
+        if 2000 <= year <= 2100:
+            return year
+    except (ValueError, IndexError):
+        pass
+    return current_monitoring_season()
+
+
 def get_plot_blob_name(monitor_id, plot_type: Literal["map", "scatter"]):
     fcast_obsv = "fcast" if "fcast" in monitor_id.lower() else "obsv"
+    year = _year_from_monitor_id(monitor_id)
     return (
-        f"{PROJECT_PREFIX}/plots/{fcast_obsv}/" f"{monitor_id}_{plot_type}.png"
+        f"{PROJECT_PREFIX}/plots/{year}/{fcast_obsv}/"
+        f"{monitor_id}_{plot_type}.png"
     )
 
 
@@ -80,8 +96,10 @@ def update_plots(
     if clobber is None:
         clobber = []
     df_monitoring = load_monitoring_data(fcast_obsv)
+    # List across all year partitions; existence is checked against the full,
+    # year-qualified blob name returned by get_plot_blob_name.
     existing_plot_blobs = stratus.list_container_blobs(
-        name_starts_with=f"{PROJECT_PREFIX}/plots/{fcast_obsv}/"
+        name_starts_with=f"{PROJECT_PREFIX}/plots/"
     )
 
     # Log email eligibility summary

--- a/src/email/utils.py
+++ b/src/email/utils.py
@@ -252,6 +252,11 @@ def load_monitoring_data(fcast_obsv: Literal["fcast", "obsv"]) -> pd.DataFrame:
     if FORCE_ALERT:
         df_monitoring = add_test_row_to_monitoring(df_monitoring, fcast_obsv)
 
+    # No data yet (e.g. start of a season): nothing to filter. Return the
+    # empty, schema-carrying frame so callers can filter/iterate safely.
+    if df_monitoring.empty:
+        return df_monitoring
+
     # Filter by MONITORING_START_DATE to limit processing scope and prevent timeouts
     df_monitoring["issue_time"] = pd.to_datetime(df_monitoring["issue_time"])
     df_monitoring = df_monitoring[

--- a/src/monitoring/monitoring_utils.py
+++ b/src/monitoring/monitoring_utils.py
@@ -12,11 +12,54 @@ import geopandas as gpd
 import ocha_stratus as stratus
 import pandas as pd
 
-from src.constants import D_THRESH, NUMERIC_NAME_REGEX, PROJECT_PREFIX, THRESHS
+from src.constants import (
+    D_THRESH,
+    NUMERIC_NAME_REGEX,
+    PROJECT_PREFIX,
+    THRESHS,
+    current_monitoring_season,
+)
 from src.datasources import codab, imerg, nhc, zma
 from src.utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+# Columns of a monitoring record. Used to build a well-formed empty frame when
+# a season has no data yet (season start, before any storm is processed) so
+# downstream consumers can filter/iterate without KeyError on missing columns.
+FCAST_MONITORING_COLUMNS = [
+    "monitor_id",
+    "atcf_id",
+    "name",
+    "issue_time",
+    "time_to_closest",
+    "closest_s",
+    "past_cutoff",
+    "min_dist",
+    "in_zma",
+    "action_s",
+    "action_trigger",
+    "readiness_s",
+    "readiness_trigger",
+]
+OBSV_MONITORING_COLUMNS = [
+    "monitor_id",
+    "atcf_id",
+    "name",
+    "issue_time",
+    "min_dist",
+    "in_zma",
+    "closest_s",
+    "obsv_s",
+    "obsv_trigger",
+    "closest_p",
+    "obsv_p",
+    "rainfall_relevant",
+    "rainfall_source",
+    "quantile_used",
+    "analysis_start",
+    "analysis_end",
+]
 
 
 # This no longer used in pipeline, but can be if we wish to use IMERG
@@ -268,11 +311,16 @@ class CubaHurricaneMonitor:
         self,
         rainfall_processor: Optional[RainfallProcessor] = None,
         rainfall_source: Optional[str] = None,
+        season: Optional[int] = None,
     ):
         self.adm0 = codab.load_codab_from_blob().to_crs(3857)
         self.zma = zma.load_zma().to_crs(3857)  # Load ZMA for filtering
         self.rainfall_processor = rainfall_processor
         self.rainfall_source = rainfall_source
+        # Season scopes both the NHC track loads and the blob partitioning
+        # (monitoring/{season}/...), so one knob keeps inputs and storage
+        # aligned.
+        self.season = season or current_monitoring_season()
 
     # ============================================================================
     # UTILITY METHODS - Single responsibility, highly reusable
@@ -338,7 +386,7 @@ class CubaHurricaneMonitor:
     ) -> pd.DataFrame:
         """Load existing monitoring points from blob storage."""
         blob_name = (
-            f"{PROJECT_PREFIX}/monitoring/"
+            f"{PROJECT_PREFIX}/monitoring/{self.season}/"
             f"cub_{monitoring_type}_monitoring.parquet"
         )
         try:
@@ -347,7 +395,16 @@ class CubaHurricaneMonitor:
             logger.info(
                 f"No existing {monitoring_type} monitoring data found."
             )
-            return pd.DataFrame()
+            # Return an empty frame that still carries the record schema, so
+            # consumers (e.g. load_monitoring_data, update_plots) can filter on
+            # issue_time / min_dist without KeyError before the season's first
+            # storm is written.
+            columns = (
+                FCAST_MONITORING_COLUMNS
+                if monitoring_type == "fcast"
+                else OBSV_MONITORING_COLUMNS
+            )
+            return pd.DataFrame(columns=columns)
 
     # ============================================================================
     # GEOMETRIC OPERATIONS
@@ -702,7 +759,7 @@ class CubaHurricaneMonitor:
     def process_forecast_tracks(self, clobber: bool = False) -> pd.DataFrame:
         """Process NHC forecast tracks into monitoring records."""
         logger.info("Loading NHC forecast tracks for Atlantic basin.")
-        df_tracks = nhc.load_recent_glb_forecasts()
+        df_tracks = nhc.load_recent_glb_forecasts(season=self.season)
         df_tracks = df_tracks[df_tracks["basin"] == "al"]
 
         df_existing = self._load_existing_monitoring("fcast")
@@ -740,7 +797,7 @@ class CubaHurricaneMonitor:
         attributes, with rainfall data added only for qualifying storms.
         """
         logger.info("Loading NHC observational tracks for Atlantic basin.")
-        obsv_tracks = nhc.load_recent_glb_obsv()
+        obsv_tracks = nhc.load_recent_glb_obsv(season=self.season)
 
         # Handle empty DataFrame case
         if obsv_tracks.empty:
@@ -1036,7 +1093,7 @@ class CubaHurricaneMonitor:
             return
 
         blob_name = (
-            f"{PROJECT_PREFIX}/monitoring/"
+            f"{PROJECT_PREFIX}/monitoring/{self.season}/"
             f"cub_{monitoring_type}_monitoring.parquet"
         )
         stratus.upload_parquet_to_blob(df, blob_name, index=False)
@@ -1363,6 +1420,7 @@ class CubaHurricaneMonitor:
 
 def create_cuba_hurricane_monitor(
     rainfall_source: Optional[str] = "raster",
+    season: Optional[int] = None,
 ) -> CubaHurricaneMonitor:
     """Factory function to create CubaHurricaneMonitor with rainfall processor.
 
@@ -1370,6 +1428,7 @@ def create_cuba_hurricane_monitor(
         rainfall_source: Type of rainfall processor
             ('imerg' for DB-based, 'raster' for raster-based, None for
             wind-only)
+        season: Atlantic season (year) to monitor. Defaults to current year.
 
     Returns:
         Configured CubaHurricaneMonitor instance
@@ -1385,7 +1444,9 @@ def create_cuba_hurricane_monitor(
         raise ValueError(f"Unsupported rainfall source: {rainfall_source}")
 
     return CubaHurricaneMonitor(
-        rainfall_processor=rainfall_processor, rainfall_source=rainfall_source
+        rainfall_processor=rainfall_processor,
+        rainfall_source=rainfall_source,
+        season=season,
     )
 
 

--- a/src/monitoring/monitoring_utils.py
+++ b/src/monitoring/monitoring_utils.py
@@ -24,9 +24,12 @@ from src.utils.logging import get_logger
 
 logger = get_logger(__name__)
 
-# Columns of a monitoring record. Used to build a well-formed empty frame when
-# a season has no data yet (season start, before any storm is processed) so
-# downstream consumers can filter/iterate without KeyError on missing columns.
+# Columns of a monitoring record, mirroring the dicts built in
+# _process_single_forecast / _process_single_observation (hand-kept in sync).
+# Used only to build a well-formed empty frame when a season has no data yet
+# (season start, before any storm is processed) so downstream consumers can
+# filter/iterate without KeyError. If a record field is added there, add it
+# to the matching list here.
 FCAST_MONITORING_COLUMNS = [
     "monitor_id",
     "atcf_id",


### PR DESCRIPTION
## Summary

First step in preparing the 2026 monitoring season. Two related changes:

**1. NHC track source: rolling CSV → dev database**
Monitoring now reads NHC tracks from `storms.nhc_tracks_geo` (joined to `storms.nhc_storms` for names) instead of the rolling global CSV snapshot (`noaa/nhc/{forecasted,observed}_tracks.csv`). The loaders in `src/datasources/nhc.py` preserve the old CSV column contract exactly — lowercase `id`, `basin='al'`, tz-aware UTC timestamps, forecasts = `leadtime>0`, observed = `leadtime=0` — so the monitor, emails, and plots are unchanged.

Because the DB is the full 1990→ archive (the CSV only ever held recent storms), the loaders scope to a single Atlantic season (current year by default, overridable) to avoid back-filling decades of history into the monitoring parquet.

> Note on time conventions: historical DB tracks come from the A-deck archive (synoptic 00/06/12/18Z); live tracks come from the TCM advisory (03/09/15/21Z) — the same product the CSVs used. So live monitoring matches prior CSV behavior. 2025 storm names are still `'NaN'` in `nhc_storms` (Tristan backfilling separately) — not relevant to 2026.

**2. Partition monitoring blobs by season**
Driven by a single `season` knob on `CubaHurricaneMonitor` (defaults to current year, also forwarded to the NHC loaders):
- `monitoring/{year}/cub_{type}_monitoring.parquet`
- `plots/{year}/{fcast,obsv}/...`

2025 blobs migrated to their `{year}/` locations manually; 2026 self-creates on first run. Generated plot paths were verified to match the existing migrated blobs exactly.

**Empty-season handling**
A fresh season's parquet doesn't exist until the first storm is written. `_load_existing_monitoring` now returns an empty frame carrying the record schema, and `load_monitoring_data` early-returns on empty — preventing email/plot consumers from crashing (`KeyError`/tz-compare `TypeError`) at season start.

## Testing
- Verified loaders match the old CSV contract (columns, dtypes, tz-awareness) against 2025 data.
- End-to-end monitor run (fcast + obsv) against the live DB for the 2026 season.
- Confirmed reads of the migrated `monitoring/2025/` archive and a clean/empty 2026 start.
- Confirmed generated plot paths match the migrated `plots/{year}/{fcast,obsv}/` blobs exactly.
- Confirmed `update_plots` / info-email consumers run clean on the empty 2026 season.
- Monitoring test suite unchanged vs. baseline (pre-existing failures only); new code is flake8-clean.

## Scope notes
- Pre-existing flake8 debt (unused imports, long lines) in `email/plotting.py`, `email/utils.py`, `monitoring_utils.py` was left untouched per change-scope discipline.
