### PR TITLE
Email cadence: once-per-issuance, daily obsv, scheduled forecast monitor

### DIFF
--- a/.github/workflows/01_run_forecast_data_ingestion.yml
+++ b/.github/workflows/01_run_forecast_data_ingestion.yml
@@ -23,7 +23,16 @@ on:
           default: "false"
           options:
             - "true"
-            - "false" 
+            - "false"
+  schedule:
+    # NHC TCM forecast advisories are issued every 6 hours at 03/09/15/21 UTC.
+    # Run 30 min later so the upstream ds-nhc-forecast pipeline has landed the
+    # advisory in the tracks DB (storms.nhc_tracks_geo) that this monitor
+    # reads. This matches the ds-storms-alerts schedule against the same data.
+    # The forecast monitor used to be triggered by the ds-nhc-forecast
+    # pipeline; that chaining no longer happens, so it runs on its own
+    # 6-hourly schedule here.
+    - cron: '30 3,9,15,21 * * *'
 jobs:
   run-script:
     runs-on: ubuntu-latest

--- a/src/email/update_emails.py
+++ b/src/email/update_emails.py
@@ -1,16 +1,20 @@
 import traceback
+from typing import Optional
 
 from src.constants import MIN_EMAIL_DISTANCE
 from src.email.send_emails import send_info_email, send_trigger_email
 from src.email.utils import (
     FORCE_ALERT,
+    filter_to_issued_time,
     load_email_record_with_test_filtering,
     load_monitoring_data,
     save_email_record,
 )
 
 
-def update_obsv_info_emails(verbose: bool = False):
+def update_obsv_info_emails(
+    verbose: bool = False, issued_time: Optional[str] = None
+):
     """Check observational monitoring data and coordinate info email sending.
 
     Iterates through observational monitoring points and calls
@@ -19,8 +23,11 @@ def update_obsv_info_emails(verbose: bool = False):
 
     Args:
         verbose: Print detailed progress messages
+        issued_time: Issuance to email for ("%Y-%m-%dT%H", UTC). Defaults to
+            the latest issuance in the data (or the ISSUED_TIME env var).
     """
     df_monitoring = load_monitoring_data("obsv")
+    df_monitoring = filter_to_issued_time(df_monitoring, issued_time)
     df_existing_email_record = load_email_record_with_test_filtering(["info"])
 
     # Log email eligibility summary with rainfall criteria
@@ -93,7 +100,9 @@ def update_obsv_info_emails(verbose: bool = False):
     save_email_record(df_existing_email_record, dicts)
 
 
-def update_fcast_info_emails(verbose: bool = False):
+def update_fcast_info_emails(
+    verbose: bool = False, issued_time: Optional[str] = None
+):
     """Check forecast monitoring data and coordinate info email sending.
 
     Iterates through forecast monitoring points and calls send_info_email()
@@ -102,8 +111,11 @@ def update_fcast_info_emails(verbose: bool = False):
 
     Args:
         verbose: Print detailed progress messages
+        issued_time: Issuance to email for ("%Y-%m-%dT%H", UTC). Defaults to
+            the latest issuance in the data (or the ISSUED_TIME env var).
     """
     df_monitoring = load_monitoring_data("fcast")
+    df_monitoring = filter_to_issued_time(df_monitoring, issued_time)
     df_existing_email_record = load_email_record_with_test_filtering(["info"])
 
     # Log email eligibility summary
@@ -163,15 +175,20 @@ def update_fcast_info_emails(verbose: bool = False):
     save_email_record(df_existing_email_record, dicts)
 
 
-def update_obsv_trigger_emails():
+def update_obsv_trigger_emails(issued_time: Optional[str] = None):
     """Check observational data and coordinate trigger email sending.
 
     Iterates through observational monitoring data grouped by storm (atcf_id)
     and calls send_trigger_email() for storms with obsv_trigger=True.
     Avoids duplicates by checking if obsv or action emails already sent.
     Updates the email record to track what was sent.
+
+    Args:
+        issued_time: Issuance to email for ("%Y-%m-%dT%H", UTC). Defaults to
+            the latest issuance in the data (or the ISSUED_TIME env var).
     """
     df_monitoring = load_monitoring_data("obsv")
+    df_monitoring = filter_to_issued_time(df_monitoring, issued_time)
     df_existing_email_record = load_email_record_with_test_filtering(["obsv"])
     dicts = []
     for atcf_id, group in df_monitoring.groupby("atcf_id"):
@@ -215,15 +232,20 @@ def update_obsv_trigger_emails():
     save_email_record(df_existing_email_record, dicts)
 
 
-def update_fcast_trigger_emails():
+def update_fcast_trigger_emails(issued_time: Optional[str] = None):
     """Check forecast data and coordinate trigger email sending.
 
     Iterates through forecast monitoring data grouped by storm (atcf_id)
     and calls send_trigger_email() for storms meeting readiness or action
     trigger criteria (not past cutoff). Checks each trigger type separately.
     Updates the email record to track what was sent.
+
+    Args:
+        issued_time: Issuance to email for ("%Y-%m-%dT%H", UTC). Defaults to
+            the latest issuance in the data (or the ISSUED_TIME env var).
     """
     df_monitoring = load_monitoring_data("fcast")
+    df_monitoring = filter_to_issued_time(df_monitoring, issued_time)
     df_existing_email_record = load_email_record_with_test_filtering(
         ["readiness", "action"]
     )

--- a/src/email/utils.py
+++ b/src/email/utils.py
@@ -2,7 +2,7 @@ import base64
 import os
 import re
 from pathlib import Path
-from typing import Literal
+from typing import Literal, Optional
 import pandas as pd
 import ocha_stratus as stratus
 from src.datasources import nhc
@@ -269,6 +269,77 @@ def load_monitoring_data(fcast_obsv: Literal["fcast", "obsv"]) -> pd.DataFrame:
     )
 
     return df_monitoring
+
+
+def _issue_time_hours_utc(series: pd.Series) -> pd.Series:
+    """issue_time values floored to the UTC hour.
+
+    NHC advisories land on whole hours (03/09/15/21Z), so flooring lets us
+    match records to a target issuance regardless of tz representation or any
+    sub-hour drift in the stored timestamp.
+    """
+    series = pd.to_datetime(series)
+    if series.dt.tz is None:
+        series = series.dt.tz_localize("UTC")
+    else:
+        series = series.dt.tz_convert("UTC")
+    return series.dt.floor("h")
+
+
+def filter_to_issued_time(
+    df_monitoring: pd.DataFrame, issued_time: Optional[str] = None
+) -> pd.DataFrame:
+    """Scope monitoring records to a single issuance ("issued time").
+
+    Each pipeline run emails for exactly ONE issued time, mirroring the
+    once-per-issuance model of the ds-storms-alerts pipeline. This replaces the
+    previous behaviour of looping over every un-emailed record in the season:
+    when the email record was empty for those records (a fresh season, or a
+    mid-season cut-over), the old loop would send the entire backlog at once,
+    one email per past issuance. Scoping to a single issuance means a run can
+    only ever email for the advisory it is processing; the email-record dedup
+    remains as a second layer against re-sends.
+
+    Target issued time, in priority order:
+      1. the explicit ``issued_time`` argument,
+      2. the ``ISSUED_TIME`` environment variable ("%Y-%m-%dT%H", UTC),
+      3. the most recent ``issue_time`` present in ``df_monitoring``.
+
+    We default to the latest issuance in the data (rather than a wall-clock
+    advisory hour as ds-storms-alerts does) because the observed feed's
+    issue_times are synthesised from observation timestamps, so the data is the
+    reliable source of "which issuance do we actually have". The ISSUED_TIME
+    override provides the same explicit, reproducible targeting for backfills
+    or replays.
+
+    Records are matched on the UTC hour of their ``issue_time``. The frame is
+    returned unchanged when FORCE_ALERT is set, so the injected test row (whose
+    issue_time is the season start, not the current advisory) still flows
+    through to the senders.
+    """
+    if FORCE_ALERT or df_monitoring.empty:
+        return df_monitoring
+
+    issue_hours = _issue_time_hours_utc(df_monitoring["issue_time"])
+
+    if issued_time is None:
+        issued_time = os.getenv("ISSUED_TIME")
+    if issued_time:
+        target = pd.Timestamp(issued_time)
+        target = (
+            target.tz_localize("UTC")
+            if target.tzinfo is None
+            else target.tz_convert("UTC")
+        ).floor("h")
+    else:
+        target = issue_hours.max()
+
+    df_at_issuance = df_monitoring[issue_hours == target]
+    print(
+        f"📌 Scoped to issued time {target:%Y-%m-%dT%H}Z: "
+        f"{len(df_at_issuance)}/{len(df_monitoring)} records"
+    )
+    return df_at_issuance
 
 
 def load_email_record_with_test_filtering(

--- a/src/monitoring/monitoring_utils.py
+++ b/src/monitoring/monitoring_utils.py
@@ -336,6 +336,34 @@ class CubaHurricaneMonitor:
         iso_time = issue_time.isoformat().split("+")[0]
         return f"{atcf_id}_{monitoring_type}_{iso_time}"
 
+    @staticmethod
+    def _daily_obsv_issue_times(lastupdate: pd.Series) -> pd.DatetimeIndex:
+        """Daily obsv issue times across a storm's observed lifecycle.
+
+        Returns one issue time per day at 15:00 UTC, the hour at which IMERG
+        observational rainfall for the prior day becomes available. This puts
+        obsv monitoring (and the obsv emails it feeds) on a once-per-day
+        cadence matching the legacy IMERG schedule, rather than the 6-hourly
+        track cadence.
+
+        The grid is bounded by the latest observation (never issues into the
+        future), so on each daily run it extends by one day as new
+        observations arrive. A storm seen only within a sub-24h window that
+        never spans a 15:00 UTC mark still gets a single record at its latest
+        observation, so it is never silently skipped.
+        """
+        start_obs = lastupdate.min()
+        end_obs = lastupdate.max()
+        issue_times = pd.date_range(
+            start=start_obs.normalize() + pd.Timedelta(hours=15),
+            end=end_obs,
+            freq="D",
+        )
+        issue_times = issue_times[issue_times >= start_obs]
+        if len(issue_times) == 0:
+            return pd.DatetimeIndex([end_obs])
+        return issue_times
+
     def _should_skip_existing(
         self, monitor_id: str, existing_data: pd.DataFrame, clobber: bool
     ) -> bool:
@@ -820,15 +848,15 @@ class CubaHurricaneMonitor:
         for atcf_id, group in obsv_tracks.groupby("atcf_id"):
             group = self._remove_track_duplicates(group, "lastUpdate")
 
-            # Create synthetic issue times every 6 hours during lifecycle
             if group.empty:
                 continue
 
-            issue_times = pd.date_range(
-                start=group["lastUpdate"].min(),
-                end=group["lastUpdate"].max(),
-                freq="6h",
-            )
+            # Daily issue times on the IMERG observational-rainfall schedule
+            # (see _daily_obsv_issue_times), so obsv monitoring and the emails
+            # it feeds run once per day rather than every 6 hours. Only the
+            # set of issue times changes; the wind+rainfall trigger computed
+            # per issue time below is unchanged.
+            issue_times = self._daily_obsv_issue_times(group["lastUpdate"])
 
             for issue_time in issue_times:
                 monitor_id = self._create_monitor_id(

--- a/tests/monitoring/test_daily_obsv_issue_times.py
+++ b/tests/monitoring/test_daily_obsv_issue_times.py
@@ -1,0 +1,61 @@
+"""Tests for the daily obsv issue-time grid.
+
+obsv monitoring records (and the obsv emails they feed) are emitted once per
+day at 15:00 UTC, the hour IMERG observational rainfall for the prior day
+becomes available — matching the legacy IMERG cadence rather than the 6-hourly
+track cadence. CubaHurricaneMonitor._daily_obsv_issue_times is the pure helper
+that builds that grid; these tests pin its behaviour.
+"""
+
+import pandas as pd
+import pytest
+
+from src.monitoring.monitoring_utils import CubaHurricaneMonitor
+
+_grid = CubaHurricaneMonitor._daily_obsv_issue_times
+
+
+@pytest.mark.unit
+class TestDailyObsvIssueTimes:
+    def test_one_mark_per_day_at_1500z(self):
+        """A multi-day storm yields one issue time per day, all at 15:00Z."""
+        obs = pd.date_range(
+            "2025-08-11T15:00Z", "2025-08-22T21:00Z", freq="6h"
+        )
+        out = _grid(pd.Series(obs))
+        assert len(out) == 12  # Aug 11..22 inclusive
+        assert (out.hour == 15).all()
+        assert (out.minute == 0).all()
+
+    def test_first_day_before_1500_is_kept(self):
+        """First observation before 15:00Z keeps that day's mark."""
+        obs = pd.date_range(
+            "2025-09-01T09:00Z", "2025-09-03T03:00Z", freq="6h"
+        )
+        out = _grid(pd.Series(obs))
+        assert [str(x) for x in out] == [
+            "2025-09-01 15:00:00+00:00",
+            "2025-09-02 15:00:00+00:00",
+        ]
+
+    def test_never_issues_past_latest_observation(self):
+        """The grid is bounded by the latest observation (no future marks),
+        so the Sep-03 15:00 mark is excluded until later obs arrive."""
+        obs = pd.date_range(
+            "2025-09-01T09:00Z", "2025-09-03T03:00Z", freq="6h"
+        )
+        out = _grid(pd.Series(obs))
+        assert out.max() <= pd.Timestamp("2025-09-03T03:00Z")
+
+    def test_single_1500_mark(self):
+        obs = pd.to_datetime(["2025-10-10T03:00Z", "2025-10-10T21:00Z"])
+        out = _grid(pd.Series(obs))
+        assert [str(x) for x in out] == ["2025-10-10 15:00:00+00:00"]
+
+    def test_subday_storm_after_1500_falls_back_to_last_obs(self):
+        """A storm seen only within a sub-24h window that never spans a
+        15:00Z mark still gets one record (at its latest observation)."""
+        obs = pd.to_datetime(["2025-10-05T18:00Z", "2025-10-05T21:00Z"])
+        out = _grid(pd.Series(obs))
+        assert len(out) == 1
+        assert str(out[0]) == "2025-10-05 21:00:00+00:00"

--- a/tests/test_filter_to_issued_time.py
+++ b/tests/test_filter_to_issued_time.py
@@ -1,0 +1,106 @@
+"""Tests for issued-time scoping of monitoring data before email sending.
+
+`filter_to_issued_time` is what makes each pipeline run email for exactly one
+issuance (the ds-storms-alerts model) instead of looping over every un-emailed
+record in the season. These tests pin that contract.
+"""
+
+import os
+
+import pandas as pd
+import pytest
+
+# src.email.utils reads SMTP settings at import time (and int-casts the port),
+# so provide dummy values before importing the module under test.
+os.environ.setdefault("DSCI_AWS_EMAIL_HOST", "localhost")
+os.environ.setdefault("DSCI_AWS_EMAIL_PORT", "587")
+os.environ.setdefault("DSCI_AWS_EMAIL_PASSWORD", "x")
+os.environ.setdefault("DSCI_AWS_EMAIL_USERNAME", "x")
+os.environ.setdefault("DSCI_AWS_EMAIL_ADDRESS", "x@example.com")
+os.environ["FORCE_ALERT"] = "false"
+
+from src.email import utils  # noqa: E402
+from src.email.utils import filter_to_issued_time  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _no_force_alert(monkeypatch):
+    """Keep FORCE_ALERT off unless a test opts in."""
+    monkeypatch.setattr(utils, "FORCE_ALERT", False)
+    monkeypatch.delenv("ISSUED_TIME", raising=False)
+
+
+@pytest.fixture
+def df_three_issuances():
+    """Three forecast issuances; two storms share the latest (15:00Z)."""
+    return pd.DataFrame(
+        {
+            "monitor_id": [
+                "al012026_fcast_2026-06-16T03:00:00",
+                "al012026_fcast_2026-06-16T15:00:00",
+                "al022026_fcast_2026-06-16T15:00:00",
+                "al012026_fcast_2026-06-15T21:00:00",
+            ],
+            "atcf_id": ["al012026", "al012026", "al022026", "al012026"],
+            "issue_time": pd.to_datetime(
+                [
+                    "2026-06-16T03:00:00Z",
+                    "2026-06-16T15:00:00Z",
+                    "2026-06-16T15:00:00Z",
+                    "2026-06-15T21:00:00Z",
+                ]
+            ),
+            "min_dist": [10.0, 20.0, 30.0, 40.0],
+        }
+    )
+
+
+def test_defaults_to_latest_issuance(df_three_issuances):
+    """With no override, only the most recent issuance is kept — across all
+    storms present at that issuance."""
+    out = filter_to_issued_time(df_three_issuances)
+    assert sorted(out["monitor_id"]) == [
+        "al012026_fcast_2026-06-16T15:00:00",
+        "al022026_fcast_2026-06-16T15:00:00",
+    ]
+
+
+def test_explicit_issued_time_argument(df_three_issuances):
+    out = filter_to_issued_time(
+        df_three_issuances, issued_time="2026-06-16T03"
+    )
+    assert out["monitor_id"].tolist() == ["al012026_fcast_2026-06-16T03:00:00"]
+
+
+def test_issued_time_env_var(df_three_issuances, monkeypatch):
+    monkeypatch.setenv("ISSUED_TIME", "2026-06-15T21")
+    out = filter_to_issued_time(df_three_issuances)
+    assert out["monitor_id"].tolist() == ["al012026_fcast_2026-06-15T21:00:00"]
+
+
+def test_explicit_arg_overrides_env(df_three_issuances, monkeypatch):
+    monkeypatch.setenv("ISSUED_TIME", "2026-06-15T21")
+    out = filter_to_issued_time(
+        df_three_issuances, issued_time="2026-06-16T03"
+    )
+    assert out["monitor_id"].tolist() == ["al012026_fcast_2026-06-16T03:00:00"]
+
+
+def test_tz_naive_issue_time_treated_as_utc(df_three_issuances):
+    df = df_three_issuances.copy()
+    df["issue_time"] = df["issue_time"].dt.tz_localize(None)
+    out = filter_to_issued_time(df)
+    assert len(out) == 2
+
+
+def test_empty_frame_returns_empty(df_three_issuances):
+    out = filter_to_issued_time(df_three_issuances.iloc[0:0])
+    assert out.empty
+
+
+def test_force_alert_bypasses_scoping(df_three_issuances, monkeypatch):
+    """The FORCE_ALERT test row carries the season-start issue_time, so
+    scoping must be bypassed or the injected row would be dropped."""
+    monkeypatch.setattr(utils, "FORCE_ALERT", True)
+    out = filter_to_issued_time(df_three_issuances)
+    assert len(out) == len(df_three_issuances)


### PR DESCRIPTION
## Summary

Follow-up to #40. Gets the Cuba hurricane email pipelines onto the right cadence and schedule.

### 1. Scope email sends to a single issuance (once-per-issuance)
All four `update_*_emails` functions iterated the *entire* season's monitoring frame and emailed every within-distance record not already in the email record. With a cold email record (fresh season / mid-season cut-over after #40 partitioned `monitoring/{year}/...`), a single run would send the **whole backlog at once** — no recency or single-issuance guard.

New `filter_to_issued_time()` in `src/email/utils.py` scopes the frame to one issuance before the existing eligibility/dedup logic. Wired into all four functions. Target issued time resolves: explicit `issued_time` arg → `ISSUED_TIME` env var (`"%Y-%m-%dT%H"`, UTC) → latest `issue_time` in the data. `FORCE_ALERT` bypasses scoping so the injected test row still reaches the senders; the email-record dedup stays as a second layer. Verified against the real 2025 season: a cold-record fcast run would have fired ~75 emails; now it fires for one issuance only.

### 2. Make obsv monitoring once-per-day on the IMERG schedule
The observed path emitted a record every **6 hours** (synthetic grid off the NHC track). Restored the legacy daily cadence: **one obsv record per storm per day at 15:00 UTC**, the hour IMERG observational rainfall for the prior day lands. Extracted into the pure helper `CubaHurricaneMonitor._daily_obsv_issue_times()`. The wind+rainfall **trigger is unchanged** — daily records are a strict subset of the old 6-hourly ones (each evaluates storm state cumulatively up to its issue time), so no trigger is lost, just evaluated at daily granularity. NHC tracks still come from the season-scoped dev-DB loaders added in #40. The grid is bounded by the latest observation (never issues into the future) and extends a day per run as observations arrive.

### 3. Schedule the forecast monitor (6-hourly, lagged)
The forecast monitor (`01_run_forecast_data_ingestion.yml`) was `workflow_dispatch`-only — it used to be triggered by the upstream `ds-nhc-forecast` pipeline, which no longer chains into it. Added `schedule: cron '30 3,9,15,21 * * *'` — 30 min after each 6-hourly NHC TCM advisory (03/09/15/21 UTC), once ds-nhc-forecast has landed the advisory in the tracks DB. This matches the `ds-storms-alerts` schedule against the same data source. Scheduled runs inherit `DRY_RUN/TEST_EMAIL/FORCE_ALERT=false` via the existing `inputs.X || 'false'` env defaults, so they send real emails. The observational monitor was already on a daily cron (`15 17 * * *`), matching the daily IMERG obsv cadence.

**Net cadence:** forecast emails per-advisory (every 6h); obsv emails once per day. Both protected from backlog blasts by the once-per-issuance scoping.

## Behaviour change to note
Trigger emails are also scoped to the issuance being processed — a trigger that fired at a *past* issuance never emailed (e.g. a missed run) won't be retro-sent. In normal cron cadence each issuance is processed in its own run, so this is the intended once-per-issuance semantics.

## Testing
- `tests/test_filter_to_issued_time.py` (7 cases) and `tests/monitoring/test_daily_obsv_issue_times.py` (5 cases) — all pass; verified against real 2025 storm spans.
- Full `tests/monitoring/` suite: identical pre-existing failures to base `origin/main` (no regressions); new code is black/isort/flake8-clean.
- Forecast workflow YAML validated (triggers: workflow_dispatch + schedule; inputs preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)