### PR TITLE
Run hurricane monitors as Databricks jobs (ephemeral clusters, listmonk backend)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,28 @@
+# ds-aa-cub-hurricanes — project notes for Claude
+
+## Architectural Decision Records (ADRs)
+
+Significant or non-obvious technical decisions in this repo are recorded as
+**ADRs** in `docs/decisions/`, using the MADR format. Copy
+`docs/decisions/template.md`; the practice itself is recorded in
+`docs/decisions/0000-use-markdown-architectural-decision-records.md`.
+
+When you make or implement a decision here, apply this lightly:
+
+- **Write an ADR when** the change settles something a future maintainer would
+  ask *"why was it done this way?"* about — a decision with real trade-offs or
+  rejected alternatives (e.g. compute model, a data-source switch, a triggering
+  mechanism, choosing a service/dependency). Routine bug fixes, refactors,
+  renames, dependency bumps, and obvious changes do **not** need one.
+- **Keep it short** — a few sentences of context, the options weighed, the choice
+  and why. The highest-value part is the *rejected* options and their cons; that
+  is what commit messages and code lose.
+- **Be non-intrusive.** Propose the ADR alongside the change; don't block work to
+  write it, and don't manufacture decisions just to document them. One ADR per
+  decision.
+- **Naming:** `NNNN-short-title-with-dashes.md`, zero-padded next number.
+- **Status** lives in the frontmatter (`proposed` → `accepted`). Supersede an old
+  ADR (mark it, link the new one) rather than silently contradicting it.
+
+If a decision is worth an ADR but now isn't the moment, say so and offer to write
+it — don't drop it silently.

--- a/databricks.yml
+++ b/databricks.yml
@@ -1,26 +1,32 @@
 # Databricks Asset Bundle — ONE bundle (`ds-aa-cub-hurricanes`) defining TWO
-# independent jobs, mirroring the two GitHub Actions monitor crons:
+# independent jobs:
 #
-#   • fcast_monitor — forecast monitor, 6-hourly (~30 min after each NHC TCM
-#                     advisory). Runs pipelines/01_update_fcast_monitor.py.
-#   • obsv_monitor  — observational (IMERG) monitor, once daily.
+#   • fcast_monitor — forecast monitor. NO schedule: it is triggered by the
+#                     upstream ds-storms-pipeline `nhc_pipeline` job (via a
+#                     run_job_task) once the NHC tracks have landed in Postgres,
+#                     which is the forecast trigger's real data dependency.
+#                     Runs pipelines/01_update_fcast_monitor.py.
+#   • obsv_monitor  — observational (IMERG) monitor, once daily on a schedule.
 #                     Runs pipelines/02_update_obsv_monitor.py.
 #
 # Both go through the thin wrapper databricks/run_monitor_job.py, which selects
-# the listmonk email backend, injects the listmonk creds from the `dsci` secret
-# scope, and shells out to the (unchanged, pure-Python) monitor script.
+# the listmonk email backend and shells out to the (unchanged, pure-Python)
+# monitor script. Each job runs on its own ephemeral single-node job cluster
+# (no dependency on anyone's personal cluster); the cluster carries the
+# DSCI_AZ_* DB/blob creds and the DSCI_LISTMONK_* sender creds, resolved from
+# the `dsci` secret scope at launch (see spark_env_vars below).
 #
 #   databricks bundle validate -p DEFAULT
 #   databricks bundle deploy   -p DEFAULT                                   # deploy prod (default target)
-#   databricks bundle run fcast_monitor -p DEFAULT                          # manual run (live params)
+#   databricks bundle run obsv_monitor  -p DEFAULT                          # manual run (live params)
 #   databricks bundle run fcast_monitor -p DEFAULT --params dry_run=True,test_email=True   # safe manual test
 #
 # The `dev` target is for feature work: deploy it on-demand pointed at a feature
-# branch — it auto-pauses both schedules and uses the test list, so it never
+# branch — it auto-pauses the obsv schedule and uses the test list, so it never
 # competes with prod. Tear it down when the feature merges:
 #
 #   databricks bundle deploy  -t dev -p DEFAULT --var git_branch=my-feature
-#   databricks bundle run     obsv_monitor -t dev -p DEFAULT               # manual test run
+#   databricks bundle run     fcast_monitor -t dev -p DEFAULT              # manual test run
 #   databricks bundle destroy -t dev -p DEFAULT
 #
 # The jobs run entirely from source: GIT at ${var.git_branch}, so shipping a
@@ -33,9 +39,6 @@ bundle:
   name: ds-aa-cub-hurricanes
 
 variables:
-  existing_cluster_id:
-    description: Interactive cluster the jobs run on (carries the DSCI_AZ_* DB/blob env vars)
-    default: "0515-161935-i2w5mxhc"
   git_branch:
     description: Branch the jobs pull the pipeline code from
     default: main
@@ -53,24 +56,78 @@ variables:
     description: '"True" = inject dummy storm data (PRUEBA prefix) to force an alert; "False" = real data only'
     default: "False"
 
+# Reusable ephemeral single-node job-cluster spec (mirrors ds-storms-pipeline's
+# prod job cluster). Single node: the monitors are plain Python, not Spark.
+# spark_env_vars are resolved from the `dsci` secret scope at cluster launch —
+# the cluster starts bare, so every credential the pipeline reads must be listed
+# here: DSCI_AZ_* (DB/blob; dev for NHC tracks, prod for IMERG) consumed by
+# ocha_stratus, and DSCI_LISTMONK_* (sender) consumed by the listmonk dispatch.
+.monitor_cluster_spec: &monitor_cluster_spec
+  spark_version: "18.2.x-scala2.13"
+  node_type_id: "Standard_DS3_v2"
+  num_workers: 0
+  spark_conf:
+    spark.databricks.cluster.profile: singleNode
+    spark.master: "local[*]"
+  custom_tags:
+    ResourceClass: SingleNode
+  data_security_mode: SINGLE_USER
+  azure_attributes:
+    availability: ON_DEMAND_AZURE
+    first_on_demand: 1
+    spot_bid_max_price: -1
+  spark_env_vars:
+    DSCI_AZ_DB_DEV_HOST: "{{secrets/dsci/DSCI_AZ_DB_DEV_HOST}}"
+    DSCI_AZ_DB_DEV_UID: "{{secrets/dsci/DSCI_AZ_DB_DEV_UID}}"
+    DSCI_AZ_DB_DEV_PW: "{{secrets/dsci/DSCI_AZ_DB_DEV_PW}}"
+    DSCI_AZ_DB_DEV_UID_WRITE: "{{secrets/dsci/DSCI_AZ_DB_DEV_UID_WRITE}}"
+    DSCI_AZ_DB_DEV_PW_WRITE: "{{secrets/dsci/DSCI_AZ_DB_DEV_PW_WRITE}}"
+    DSCI_AZ_DB_PROD_HOST: "{{secrets/dsci/DSCI_AZ_DB_PROD_HOST}}"
+    DSCI_AZ_DB_PROD_UID: "{{secrets/dsci/DSCI_AZ_DB_PROD_UID}}"
+    DSCI_AZ_DB_PROD_PW: "{{secrets/dsci/DSCI_AZ_DB_PROD_PW}}"
+    DSCI_AZ_BLOB_DEV_SAS: "{{secrets/dsci/DSCI_AZ_BLOB_DEV_SAS}}"
+    DSCI_AZ_BLOB_DEV_SAS_WRITE: "{{secrets/dsci/DSCI_AZ_BLOB_DEV_SAS_WRITE}}"
+    DSCI_AZ_BLOB_PROD_SAS: "{{secrets/dsci/DSCI_AZ_BLOB_PROD_SAS}}"
+    DSCI_LISTMONK_BASE_URL: "{{secrets/dsci/DSCI_LISTMONK_BASE_URL}}"
+    DSCI_LISTMONK_API_USERNAME: "{{secrets/dsci/DSCI_LISTMONK_API_USERNAME}}"
+    DSCI_LISTMONK_API_KEY: "{{secrets/dsci/DSCI_LISTMONK_API_KEY}}"
+
+# Shared library list. Pinned to requirements.txt where the repo pins, so the
+# job runs the versions the pipeline was tested against. numpy/pandas are left
+# to the cluster runtime (DBR base) to avoid fighting its core scientific stack.
+# xarray/rioxarray are needed by the IMERG raster path (obsv) and at import for
+# both monitors.
+.cub_libs: &cub_libs
+  - pypi: { package: "ocha-stratus==0.1.2" }
+  - pypi:
+      package: "ocha-relay @ git+https://github.com/OCHA-DAP/ocha-relay.git@v0.3.0"
+  - pypi: { package: "geopandas==1.0.1" }
+  - pypi: { package: "xarray==2025.4.0" }
+  - pypi: { package: "rioxarray==0.19.0" }
+  - pypi: { package: "matplotlib==3.10.3" }
+  - pypi: { package: "plotly==5.24.1" }
+  - pypi: { package: "kaleido==0.2.1" }
+  - pypi: { package: "pytz==2024.2" }
+  - pypi: { package: "html2text==2024.2.26" }
+  - pypi: { package: "Jinja2==3.1.6" }
+  - pypi: { package: "requests>=2.31.0" }
+  - pypi: { package: "tqdm==4.67.1" }
+
 targets:
   prod:
-    # The live jobs (default target). Production mode runs the schedules as
-    # defined. (run_as / a shared root_path can be revisited when cutting over
-    # off a personal identity.)
+    # The live jobs (default target). Production mode runs the obsv schedule as
+    # defined and leaves fcast trigger-only.
     mode: production
     default: true
     workspace:
       profile: DEFAULT
       root_path: /Workspace/Users/adm.zarno1@global.un.org/.bundle/${bundle.name}/${bundle.target}
     variables:
-      # Live: send to the real info/trigger subscriber lists (not the test
-      # list). Still reads the DEV database (the monitors are stage-fixed in
-      # code); IMERG reads from prod blob/DB internally.
+      # Live: send to the real info/trigger subscriber lists (not the test list).
       test_email: "False"
   dev:
     # On-demand feature-branch testing only — deploy with --var git_branch=<branch>.
-    # Development mode auto-pauses the schedules and prefixes the job names
+    # Development mode auto-pauses the obsv schedule and prefixes the job names
     # ("[dev <user>] ..."), and test_email defaults to True (test list), so it
     # never competes with the live prod jobs. Destroy when done.
     mode: development
@@ -81,9 +138,10 @@ resources:
   jobs:
 
     # ===================================================================
-    # Forecast monitor — single task, 6-hourly. ~30 min after each NHC TCM
-    # forecast advisory (03/09/15/21 UTC) so the upstream tracks have landed
-    # in storms.nhc_tracks_geo. Matches the old GHA "Forecast Monitor" cron.
+    # Forecast monitor — single task, NO schedule. Triggered by the upstream
+    # ds-storms-pipeline `nhc_pipeline` job (run_job_task) once NHC tracks have
+    # landed in storms.nhc_tracks_geo, which is the forecast trigger's actual
+    # data dependency. Can also be run manually for tests/backfills.
     # ===================================================================
     fcast_monitor:
       name: Cuba Hurricane Forecast Monitor
@@ -91,14 +149,6 @@ resources:
         git_url: https://github.com/OCHA-DAP/ds-aa-cub-hurricanes.git
         git_provider: gitHub
         git_branch: ${var.git_branch}
-
-      schedule:
-        # 03:30 / 09:30 / 15:30 / 21:30 UTC. No explicit pause_status: prod
-        # (production mode) runs it; the dev target (development mode) auto-
-        # pauses it. Setting UNPAUSED here would override dev's auto-pause and
-        # make dev fire too — don't.
-        quartz_cron_expression: "0 30 3,9,15,21 * * ?"
-        timezone_id: UTC
 
       max_concurrent_runs: 1
 
@@ -110,9 +160,13 @@ resources:
         - name: force_alert    # run-mode switch (see variables block)
           default: ${var.force_alert}
 
+      job_clusters:
+        - job_cluster_key: monitor_cluster
+          new_cluster: *monitor_cluster_spec
+
       tasks:
         - task_key: run_fcast
-          existing_cluster_id: ${var.existing_cluster_id}
+          job_cluster_key: monitor_cluster
           spark_python_task:
             python_file: databricks/run_monitor_job.py
             source: GIT
@@ -121,27 +175,7 @@ resources:
               - "{{job.parameters.dry_run}}"
               - "{{job.parameters.test_email}}"
               - "{{job.parameters.force_alert}}"
-          libraries: &cub_libs
-            # Pinned to requirements.txt where the repo pins, so the job runs
-            # the versions the pipeline was tested against. numpy/pandas are
-            # left to the cluster runtime (DBR base) to avoid fighting its core
-            # scientific stack. xarray/rioxarray are needed by the IMERG raster
-            # path (obsv) and at import for both monitors.
-            - pypi: { package: "ocha-stratus==0.1.2" }
-            - pypi:
-                package: "ocha-relay @ git+https://github.com/OCHA-DAP/ocha-relay.git@v0.3.0"
-            - pypi: { package: "geopandas==1.0.1" }
-            - pypi: { package: "xarray==2025.4.0" }
-            - pypi: { package: "rioxarray==0.19.0" }
-            - pypi: { package: "matplotlib==3.10.3" }
-            - pypi: { package: "plotly==5.24.1" }
-            - pypi: { package: "kaleido==0.2.1" }
-            - pypi: { package: "pytz==2024.2" }
-            - pypi: { package: "html2text==2024.2.26" }
-            - pypi: { package: "Jinja2==3.1.6" }
-            - pypi: { package: "requests>=2.31.0" }
-            - pypi: { package: "tqdm==4.67.1" }
-            - pypi: { package: "databricks-sdk" }
+          libraries: *cub_libs
 
     # ===================================================================
     # Observational monitor — single task, once daily at 17:15 UTC. Processes
@@ -155,6 +189,9 @@ resources:
         git_branch: ${var.git_branch}
 
       schedule:
+        # 17:15 UTC daily. No explicit pause_status: prod (production mode) runs
+        # it; the dev target (development mode) auto-pauses it. Setting UNPAUSED
+        # here would override dev's auto-pause and make dev fire too — don't.
         quartz_cron_expression: "0 15 17 * * ?"
         timezone_id: UTC
 
@@ -168,9 +205,13 @@ resources:
         - name: force_alert
           default: ${var.force_alert}
 
+      job_clusters:
+        - job_cluster_key: monitor_cluster
+          new_cluster: *monitor_cluster_spec
+
       tasks:
         - task_key: run_obsv
-          existing_cluster_id: ${var.existing_cluster_id}
+          job_cluster_key: monitor_cluster
           spark_python_task:
             python_file: databricks/run_monitor_job.py
             source: GIT

--- a/databricks.yml
+++ b/databricks.yml
@@ -113,6 +113,21 @@ variables:
   - pypi: { package: "requests>=2.31.0" }
   - pypi: { package: "tqdm==4.67.1" }
 
+# Both jobs clone this repo and take the same run-mode parameters; shared here so
+# the two job definitions can't drift apart.
+.git_source: &git_source
+  git_url: https://github.com/OCHA-DAP/ds-aa-cub-hurricanes.git
+  git_provider: gitHub
+  git_branch: ${var.git_branch}
+
+.monitor_params: &monitor_params
+  - name: dry_run        # run-mode switch (see variables block)
+    default: ${var.dry_run}
+  - name: test_email     # run-mode switch (see variables block)
+    default: ${var.test_email}
+  - name: force_alert    # run-mode switch (see variables block)
+    default: ${var.force_alert}
+
 targets:
   prod:
     # The live jobs (default target). Production mode runs the obsv schedule as
@@ -145,20 +160,11 @@ resources:
     # ===================================================================
     fcast_monitor:
       name: Cuba Hurricane Forecast Monitor
-      git_source:
-        git_url: https://github.com/OCHA-DAP/ds-aa-cub-hurricanes.git
-        git_provider: gitHub
-        git_branch: ${var.git_branch}
+      git_source: *git_source
 
       max_concurrent_runs: 1
 
-      parameters:
-        - name: dry_run        # run-mode switch (see variables block)
-          default: ${var.dry_run}
-        - name: test_email     # run-mode switch (see variables block)
-          default: ${var.test_email}
-        - name: force_alert    # run-mode switch (see variables block)
-          default: ${var.force_alert}
+      parameters: *monitor_params
 
       job_clusters:
         - job_cluster_key: monitor_cluster
@@ -183,10 +189,7 @@ resources:
     # ===================================================================
     obsv_monitor:
       name: Cuba Hurricane Observational Monitor
-      git_source:
-        git_url: https://github.com/OCHA-DAP/ds-aa-cub-hurricanes.git
-        git_provider: gitHub
-        git_branch: ${var.git_branch}
+      git_source: *git_source
 
       schedule:
         # 17:15 UTC daily. No explicit pause_status: prod (production mode) runs
@@ -197,13 +200,7 @@ resources:
 
       max_concurrent_runs: 1
 
-      parameters:
-        - name: dry_run
-          default: ${var.dry_run}
-        - name: test_email
-          default: ${var.test_email}
-        - name: force_alert
-          default: ${var.force_alert}
+      parameters: *monitor_params
 
       job_clusters:
         - job_cluster_key: monitor_cluster

--- a/databricks.yml
+++ b/databricks.yml
@@ -1,0 +1,182 @@
+# Databricks Asset Bundle — ONE bundle (`ds-aa-cub-hurricanes`) defining TWO
+# independent jobs, mirroring the two GitHub Actions monitor crons:
+#
+#   • fcast_monitor — forecast monitor, 6-hourly (~30 min after each NHC TCM
+#                     advisory). Runs pipelines/01_update_fcast_monitor.py.
+#   • obsv_monitor  — observational (IMERG) monitor, once daily.
+#                     Runs pipelines/02_update_obsv_monitor.py.
+#
+# Both go through the thin wrapper databricks/run_monitor_job.py, which selects
+# the listmonk email backend, injects the listmonk creds from the `dsci` secret
+# scope, and shells out to the (unchanged, pure-Python) monitor script.
+#
+#   databricks bundle validate -p DEFAULT
+#   databricks bundle deploy   -p DEFAULT                                   # deploy prod (default target)
+#   databricks bundle run fcast_monitor -p DEFAULT                          # manual run (live params)
+#   databricks bundle run fcast_monitor -p DEFAULT --params dry_run=True,test_email=True   # safe manual test
+#
+# The `dev` target is for feature work: deploy it on-demand pointed at a feature
+# branch — it auto-pauses both schedules and uses the test list, so it never
+# competes with prod. Tear it down when the feature merges:
+#
+#   databricks bundle deploy  -t dev -p DEFAULT --var git_branch=my-feature
+#   databricks bundle run     obsv_monitor -t dev -p DEFAULT               # manual test run
+#   databricks bundle destroy -t dev -p DEFAULT
+#
+# The jobs run entirely from source: GIT at ${var.git_branch}, so shipping a
+# code change = pushing the branch. A `bundle deploy` is only needed when the
+# job *config* (schedule, params, libraries, cluster) changes.
+#
+# Bundle docs: https://docs.databricks.com/dev-tools/bundles/
+
+bundle:
+  name: ds-aa-cub-hurricanes
+
+variables:
+  existing_cluster_id:
+    description: Interactive cluster the jobs run on (carries the DSCI_AZ_* DB/blob env vars)
+    default: "0515-161935-i2w5mxhc"
+  git_branch:
+    description: Branch the jobs pull the pipeline code from
+    default: main
+  # Run-mode switches (the DBX analog of the GHA repo vars / workflow inputs).
+  # Flip without editing files via, e.g.:
+  #   databricks bundle deploy -p DEFAULT --var test_email=False
+  dry_run:
+    description: '"True" = run monitor but skip send/write; "False" = actually send/write'
+    default: "False"
+  test_email:
+    # Default is the safe test list; the prod target overrides to "False" below.
+    description: '"True" = route all sends to the [TEST] list; "False" = real info/trigger audiences'
+    default: "True"
+  force_alert:
+    description: '"True" = inject dummy storm data (PRUEBA prefix) to force an alert; "False" = real data only'
+    default: "False"
+
+targets:
+  prod:
+    # The live jobs (default target). Production mode runs the schedules as
+    # defined. (run_as / a shared root_path can be revisited when cutting over
+    # off a personal identity.)
+    mode: production
+    default: true
+    workspace:
+      profile: DEFAULT
+      root_path: /Workspace/Users/adm.zarno1@global.un.org/.bundle/${bundle.name}/${bundle.target}
+    variables:
+      # Live: send to the real info/trigger subscriber lists (not the test
+      # list). Still reads the DEV database (the monitors are stage-fixed in
+      # code); IMERG reads from prod blob/DB internally.
+      test_email: "False"
+  dev:
+    # On-demand feature-branch testing only — deploy with --var git_branch=<branch>.
+    # Development mode auto-pauses the schedules and prefixes the job names
+    # ("[dev <user>] ..."), and test_email defaults to True (test list), so it
+    # never competes with the live prod jobs. Destroy when done.
+    mode: development
+    workspace:
+      profile: DEFAULT
+
+resources:
+  jobs:
+
+    # ===================================================================
+    # Forecast monitor — single task, 6-hourly. ~30 min after each NHC TCM
+    # forecast advisory (03/09/15/21 UTC) so the upstream tracks have landed
+    # in storms.nhc_tracks_geo. Matches the old GHA "Forecast Monitor" cron.
+    # ===================================================================
+    fcast_monitor:
+      name: Cuba Hurricane Forecast Monitor
+      git_source:
+        git_url: https://github.com/OCHA-DAP/ds-aa-cub-hurricanes.git
+        git_provider: gitHub
+        git_branch: ${var.git_branch}
+
+      schedule:
+        # 03:30 / 09:30 / 15:30 / 21:30 UTC. No explicit pause_status: prod
+        # (production mode) runs it; the dev target (development mode) auto-
+        # pauses it. Setting UNPAUSED here would override dev's auto-pause and
+        # make dev fire too — don't.
+        quartz_cron_expression: "0 30 3,9,15,21 * * ?"
+        timezone_id: UTC
+
+      max_concurrent_runs: 1
+
+      parameters:
+        - name: dry_run        # run-mode switch (see variables block)
+          default: ${var.dry_run}
+        - name: test_email     # run-mode switch (see variables block)
+          default: ${var.test_email}
+        - name: force_alert    # run-mode switch (see variables block)
+          default: ${var.force_alert}
+
+      tasks:
+        - task_key: run_fcast
+          existing_cluster_id: ${var.existing_cluster_id}
+          spark_python_task:
+            python_file: databricks/run_monitor_job.py
+            source: GIT
+            parameters:
+              - "fcast"
+              - "{{job.parameters.dry_run}}"
+              - "{{job.parameters.test_email}}"
+              - "{{job.parameters.force_alert}}"
+          libraries: &cub_libs
+            # Pinned to requirements.txt where the repo pins, so the job runs
+            # the versions the pipeline was tested against. numpy/pandas are
+            # left to the cluster runtime (DBR base) to avoid fighting its core
+            # scientific stack. xarray/rioxarray are needed by the IMERG raster
+            # path (obsv) and at import for both monitors.
+            - pypi: { package: "ocha-stratus==0.1.2" }
+            - pypi:
+                package: "ocha-relay @ git+https://github.com/OCHA-DAP/ocha-relay.git@v0.3.0"
+            - pypi: { package: "geopandas==1.0.1" }
+            - pypi: { package: "xarray==2025.4.0" }
+            - pypi: { package: "rioxarray==0.19.0" }
+            - pypi: { package: "matplotlib==3.10.3" }
+            - pypi: { package: "plotly==5.24.1" }
+            - pypi: { package: "kaleido==0.2.1" }
+            - pypi: { package: "pytz==2024.2" }
+            - pypi: { package: "html2text==2024.2.26" }
+            - pypi: { package: "Jinja2==3.1.6" }
+            - pypi: { package: "requests>=2.31.0" }
+            - pypi: { package: "tqdm==4.67.1" }
+            - pypi: { package: "databricks-sdk" }
+
+    # ===================================================================
+    # Observational monitor — single task, once daily at 17:15 UTC. Processes
+    # IMERG rainfall (raster). Matches the old GHA "Observational Monitor" cron.
+    # ===================================================================
+    obsv_monitor:
+      name: Cuba Hurricane Observational Monitor
+      git_source:
+        git_url: https://github.com/OCHA-DAP/ds-aa-cub-hurricanes.git
+        git_provider: gitHub
+        git_branch: ${var.git_branch}
+
+      schedule:
+        quartz_cron_expression: "0 15 17 * * ?"
+        timezone_id: UTC
+
+      max_concurrent_runs: 1
+
+      parameters:
+        - name: dry_run
+          default: ${var.dry_run}
+        - name: test_email
+          default: ${var.test_email}
+        - name: force_alert
+          default: ${var.force_alert}
+
+      tasks:
+        - task_key: run_obsv
+          existing_cluster_id: ${var.existing_cluster_id}
+          spark_python_task:
+            python_file: databricks/run_monitor_job.py
+            source: GIT
+            parameters:
+              - "obsv"
+              - "{{job.parameters.dry_run}}"
+              - "{{job.parameters.test_email}}"
+              - "{{job.parameters.force_alert}}"
+          libraries: *cub_libs

--- a/databricks/README.md
+++ b/databricks/README.md
@@ -1,0 +1,125 @@
+# Databricks jobs — Cuba hurricane monitors
+
+The two Cuba hurricane monitors run as scheduled **Databricks jobs** (defined in
+the repo-root `databricks.yml`), mirroring the two GitHub Actions monitor crons:
+
+| Job | Schedule (UTC) | Script |
+|---|---|---|
+| `fcast_monitor` | `30 3,9,15,21 * * *` (6-hourly, ~30 min after each NHC advisory) | `pipelines/01_update_fcast_monitor.py` |
+| `obsv_monitor`  | `15 17 * * *` (once daily) | `pipelines/02_update_obsv_monitor.py` |
+
+This is the production deployment vehicle for the listmonk email backend: the
+jobs run with `EMAIL_BACKEND=listmonk`. The GitHub Actions monitor workflows
+(`Forecast Monitor`, `Observational Monitor`) stay disabled as the manual
+fallback (they still send via the humdata_email SMTP path).
+
+## Architecture
+
+- One bundle, two jobs, each a single `spark_python_task`.
+- `source: GIT` clones this repo at `${var.git_branch}` **at run time**, so
+  shipping a code change = pushing the branch (no redeploy needed). A
+  `bundle deploy` is only needed when the *job config* (schedule, params,
+  libraries, cluster) changes.
+- Each task runs the thin wrapper `databricks/run_monitor_job.py`, which selects
+  the monitor (`fcast`/`obsv`), injects the listmonk creds from the `dsci`
+  secret scope, sets `EMAIL_BACKEND=listmonk` and the run-mode env vars, and
+  shells out to the monitor script. Pipeline code (`pipelines/`, `src/`) stays
+  pure Python and DBX-agnostic — the GHA workflows run the same scripts.
+- Compute: the existing interactive cluster `${var.existing_cluster_id}` (the
+  one ds-storms-pipeline uses), which already carries the `DSCI_AZ_*` DB/blob
+  env vars — including the `*_PROD_*` ones the IMERG raster path reads.
+
+## Target model — one live deploy, dev on demand
+
+**Don't run two standing deploys.** Two targets scheduled on the same branch
+just fire twice per advisory.
+
+- **`prod`** (default target) is the only normally-deployed bundle. It serves the
+  scheduled runs *and* ad-hoc manual runs (override params per run). Live params:
+  `dry_run=False`, `test_email=False`, `force_alert=False`.
+- **`dev`** is deployed **on demand for feature work**, pointed at a feature
+  branch. Development mode auto-pauses both schedules and defaults to the test
+  list, so it never competes with prod. Destroy it when the feature merges.
+
+## Common commands
+
+```bash
+# --- Live jobs (prod is the default target) ---
+databricks bundle validate -p DEFAULT
+databricks bundle deploy   -p DEFAULT                                       # deploy/update the live jobs
+databricks bundle run fcast_monitor -p DEFAULT                              # manual run — SENDS FOR REAL
+databricks bundle run fcast_monitor -p DEFAULT --params dry_run=True,test_email=True   # safe manual test
+databricks bundle run obsv_monitor  -p DEFAULT --params dry_run=True,test_email=True
+
+# --- Feature development (throwaway dev jobs from your branch) ---
+databricks bundle deploy  -t dev -p DEFAULT --var git_branch=my-feature
+databricks bundle run     fcast_monitor -t dev -p DEFAULT   # paused schedule, test list
+databricks bundle destroy -t dev -p DEFAULT                 # when the feature merges
+```
+
+## Run-mode params (the GHA-vars analog)
+
+`dry_run`, `test_email`, and `force_alert` are bundle **variables** wired into
+each job's parameter defaults, so the mode flips at deploy time without editing
+files (`--var test_email=False`). Per run, override with `--params`.
+
+| | `dry_run` | `test_email` | `force_alert` |
+|---|---|---|---|
+| `"True"` | run monitor but **skip** send/write | route all sends to the **[TEST] list** | inject **dummy storm data** (PRUEBA) to force an alert |
+| `"False"` | **actually send/write** | send to the **real info/trigger audiences** | real data only |
+
+⚠️ The default target is the **live** one: a bare `bundle run fcast_monitor`
+**sends for real**. For a safe manual check pass
+`--params dry_run=True,test_email=True`, or use a `dev` deploy.
+
+## Prerequisites (one-time)
+
+1. Workspace GitHub credentials for this repo (same mechanism as
+   ds-storms-pipeline).
+2. Listmonk **sender** config in the `dsci` secret scope (already present —
+   shared with ds-storms-alerts):
+   `DSCI_LISTMONK_BASE_URL`, `DSCI_LISTMONK_API_USERNAME`, `DSCI_LISTMONK_API_KEY`.
+3. The listmonk lists + dual-language template must exist on the instance the
+   `DSCI_LISTMONK_BASE_URL` points at (run `pipelines/setup_cub_listmonk_lists.py`).
+
+## Go-live checklist (nothing fires automatically on merge)
+
+Merging this only adds the bundle definition — it does **not** deploy or
+schedule anything. To take the monitors live on Databricks:
+
+1. **Provision the production listmonk instance** + recreate the lists/template
+   and point `dsci/DSCI_LISTMONK_BASE_URL` at it (currently the demo instance).
+2. **Import the real subscribers** to the info/trigger lists.
+3. `databricks bundle deploy -p DEFAULT` — deploys both prod jobs (schedules
+   active in production mode). Confirm `dry_run=False`, `test_email=False`.
+4. Leave the GitHub Actions monitor workflows **disabled** (they're the manual
+   fallback). Re-enabling them while the DBX jobs run would double-fire.
+
+## Gotchas / best practices (from the ds-storms-alerts deploy)
+
+- **Don't set `schedule.pause_status: UNPAUSED` in the resource.** It overrides
+  development mode's auto-pause and makes the `dev` jobs fire on the cron too.
+  Leave it unset: production mode keeps prod running; development mode pauses dev.
+- **The wrapper must not call `sys.exit()` at the top level.** `spark_python_task`
+  treats a top-level `SystemExit` — *even code 0* — as a task failure. The wrapper
+  raises an exception only on a non-zero child exit; success returns naturally.
+- **Verify runs from the task logs, not the CLI exit code.** `databricks bundle run`
+  can report exit 0 while the task itself failed. Check the run output for the
+  monitor's log lines (or `databricks jobs get-run-output <task_run_id>`).
+- **`source: GIT` means runtime = branch HEAD.** Pushing the branch updates the
+  next run automatically; only config changes need a `bundle deploy`.
+- **`matplotlib` needs a writable config dir** on the cluster (`MPLCONFIGDIR=/tmp/...`),
+  since the cloned repo lives on the read-only workspace FUSE mount.
+- **Library versions track `requirements.txt`.** `numpy`/`pandas` are left to the
+  cluster runtime (DBR base); the rest are pinned. If a pin conflicts with the
+  runtime, loosen it in `databricks.yml` and document why.
+
+## Rollback
+
+Re-enable the GitHub Actions schedules (the humdata_email fallback):
+```bash
+gh workflow enable "Forecast Monitor"
+gh workflow enable "Observational Monitor"
+```
+Pause the DBX jobs in the workspace UI, or `databricks bundle destroy -p DEFAULT`.
+Revert a deploy to the test list: `databricks bundle deploy -p DEFAULT --var test_email=True`.

--- a/databricks/README.md
+++ b/databricks/README.md
@@ -32,15 +32,21 @@ daily schedule.
   libraries, cluster) changes.
 - Each task runs the thin wrapper `databricks/run_monitor_job.py`, which selects
   the monitor (`fcast`/`obsv`), sets `EMAIL_BACKEND=listmonk` and the run-mode
-  env vars, and shells out to the monitor script. Pipeline code (`pipelines/`,
-  `src/`) stays pure Python and DBX-agnostic — the GHA workflows run the same
-  scripts.
+  env vars, **copies `src` + `pipelines` from the wsfs-mounted clone onto local
+  disk**, and shells out to the monitor script from there. Pipeline code
+  (`pipelines/`, `src/`) stays pure Python and DBX-agnostic — the GHA workflows
+  run the same scripts. (The copy-to-local step is required because importing
+  Python packages off the wsfs FUSE mount is unreliable — see Gotchas.)
 - **Compute: an ephemeral single-node job cluster per run** (not anyone's
   personal interactive cluster). It starts bare, so every credential the
   pipeline reads is injected from the `dsci` secret scope via the cluster's
   `spark_env_vars`: `DSCI_AZ_*` (DB/blob — dev for NHC tracks, prod for IMERG,
   consumed by ocha_stratus) and `DSCI_LISTMONK_*` (sender creds, consumed by the
-  listmonk dispatch).
+  listmonk dispatch). Ephemeral was a deliberate choice over a warm
+  pre-installed cluster: the AA lead times are days, so the ~15–20 min cold
+  start + library install per run is operationally negligible, and we keep the
+  reproducible / person-independent / zero-idle-cost properties. See "Startup
+  time" below for the trade-offs and possible optimizations.
 
 ## Target model — one live deploy, dev on demand
 
@@ -127,11 +133,40 @@ schedule anything. To take the monitors live on Databricks:
   monitor's log lines (or `databricks jobs get-run-output <task_run_id>`).
 - **`source: GIT` means runtime = branch HEAD.** Pushing the branch updates the
   next run automatically; only config changes need a `bundle deploy`.
-- **`matplotlib` needs a writable config dir** on the cluster (`MPLCONFIGDIR=/tmp/...`),
-  since the cloned repo lives on the read-only workspace FUSE mount.
+- **Don't import Python code directly off the wsfs mount.** Under `source: GIT`
+  the repo is cloned onto the workspace FUSE mount (wsfs), which raises hard
+  filesystem errors (not a clean "not found") when the import machinery probes
+  candidate filenames per module (`__init__.cpython-*.so`, `matplotlibrc`,
+  `__pycache__`, …). This intermittently breaks `from src ...`. The wrapper
+  copies `src` + `pipelines` to `/local_disk0` and runs from there; if you add a
+  new top-level package the pipeline imports, add it to that copy list.
+- **`matplotlib` needs a writable config dir** (`MPLCONFIGDIR=/tmp/...`).
 - **Library versions track `requirements.txt`.** `numpy`/`pandas` are left to the
   cluster runtime (DBR base); the rest are pinned. If a pin conflicts with the
   runtime, loosen it in `databricks.yml` and document why.
+
+## Startup time & possible optimizations
+
+Each run is ~15–20 min before the monitor logic starts, almost all of it
+**library install** on the bare ephemeral cluster (geopandas, rioxarray, xarray,
+kaleido, `ocha-relay` from git), not cluster boot (~4 min). This is accepted on
+purpose (see Architecture). If it ever needs cutting, in rough order of
+leverage/risk:
+
+- **Trim the dependency list** — lean on the DBR base where possible and drop
+  `plotly`/`kaleido` if matplotlib can render the map/scatter plots (kaleido is a
+  large chunk of the install). Stacks with any compute model.
+- **Serverless jobs compute** — fast start + env caching, scale-to-zero; needs
+  serverless enabled, network config to reach Azure Postgres/blob, and a check
+  that the geo stack installs cleanly.
+- **Custom container image / init script** with the libs baked in — near-zero
+  install, still reproducible; costs an image to build and maintain.
+- An **instance pool** alone is low ROI: it shaves the ~4 min boot, not the
+  ~15 min install.
+- A warm **all-purpose cluster** with libs pre-installed is fastest per-run but
+  was rejected for prod: single-user ACLs, idle cost, mutable shared state, and
+  the lib set living off-bundle (drifts from `requirements.txt`). Fine as a
+  *dev-only* convenience if you want faster iteration.
 
 ## Rollback
 

--- a/databricks/README.md
+++ b/databricks/README.md
@@ -107,15 +107,23 @@ files (`--var test_email=False`). Per run, override with `--params`.
 Merging this only adds the bundle definition — it does **not** deploy or
 schedule anything. To take the monitors live on Databricks:
 
-1. **Provision the production listmonk instance** + recreate the lists/template
-   and point `dsci/DSCI_LISTMONK_BASE_URL` at it (currently the demo instance).
-2. **Import the real subscribers** to the info/trigger lists.
-3. `databricks bundle deploy -p DEFAULT` — deploys both prod jobs (obsv schedule
+1. **Import the real subscribers** into the info/trigger lists
+   (`python pipelines/setup_cub_listmonk_lists.py`). They are created with
+   `attribs.type=mailing_list`, so the campaign template omits the unsubscribe
+   link for them.
+2. `databricks bundle deploy -p DEFAULT` — deploys both prod jobs (obsv schedule
    active; fcast trigger-only). Confirm `dry_run=False`, `test_email=False`.
-4. Deploy the matching `ds-storms-pipeline` change so `nhc_pipeline` triggers the
-   prod `fcast_monitor` (point its `cub_fcast_job_id` var at the prod job id).
-5. Leave the GitHub Actions monitor workflows **disabled** (the manual fallback).
-   Re-enabling them while the DBX jobs run would double-fire.
+   (Unattended sending already works: the wrapper sets
+   `LISTMONK_SKIP_CONFIRMATION=true`.)
+3. Deploy the matching `ds-storms-pipeline` change so `nhc_pipeline` triggers the
+   prod `fcast_monitor` (point its `cub_fcast_job_id` var at the prod job id) —
+   OCHA-DAP/ds-storms-pipeline#33.
+4. Leave the GitHub Actions monitor workflows **disabled**. They are retired, not
+   a live fallback: listmonk is now the default backend and GitHub carries no
+   listmonk creds, so re-enabling one would fail rather than send.
+
+There is a single listmonk instance; if a separate production instance is ever
+added, repoint `dsci/DSCI_LISTMONK_BASE_URL` and re-run the setup script then.
 
 ## Gotchas / best practices (from the ds-storms-alerts/pipeline deploys)
 
@@ -170,10 +178,12 @@ leverage/risk:
 
 ## Rollback
 
-Re-enable the GitHub Actions schedules (the humdata_email fallback):
-```bash
-gh workflow enable "Forecast Monitor"
-gh workflow enable "Observational Monitor"
-```
-Pause the DBX jobs in the workspace UI, or `databricks bundle destroy -p DEFAULT`.
-Revert a deploy to the test list: `databricks bundle deploy -p DEFAULT --var test_email=True`.
+Stop the DBX jobs: pause them in the workspace UI, or
+`databricks bundle destroy -p DEFAULT`. Revert a deploy to the test list:
+`databricks bundle deploy -p DEFAULT --var test_email=True`.
+
+The humdata_email SMTP path remains as a manual escape hatch, but it is **not**
+the GitHub Actions workflows: listmonk is the default backend and GitHub has no
+listmonk creds, so re-enabling those workflows would fail, not send. To use the
+SMTP fallback, run a monitor with `EMAIL_BACKEND=humdata_email` in an environment
+that has the `DSCI_AWS_EMAIL_*` creds.

--- a/databricks/README.md
+++ b/databricks/README.md
@@ -1,17 +1,27 @@
 # Databricks jobs — Cuba hurricane monitors
 
-The two Cuba hurricane monitors run as scheduled **Databricks jobs** (defined in
-the repo-root `databricks.yml`), mirroring the two GitHub Actions monitor crons:
+The two Cuba hurricane monitors run as **Databricks jobs** (defined in the
+repo-root `databricks.yml`):
 
-| Job | Schedule (UTC) | Script |
+| Job | Trigger | Script |
 |---|---|---|
-| `fcast_monitor` | `30 3,9,15,21 * * *` (6-hourly, ~30 min after each NHC advisory) | `pipelines/01_update_fcast_monitor.py` |
-| `obsv_monitor`  | `15 17 * * *` (once daily) | `pipelines/02_update_obsv_monitor.py` |
+| `fcast_monitor` | **Run-job task from `ds-storms-pipeline`'s `nhc_pipeline`** (once NHC tracks land in Postgres). No own schedule. | `pipelines/01_update_fcast_monitor.py` |
+| `obsv_monitor`  | Schedule `15 17 * * *` (once daily, UTC) | `pipelines/02_update_obsv_monitor.py` |
 
 This is the production deployment vehicle for the listmonk email backend: the
 jobs run with `EMAIL_BACKEND=listmonk`. The GitHub Actions monitor workflows
 (`Forecast Monitor`, `Observational Monitor`) stay disabled as the manual
 fallback (they still send via the humdata_email SMTP path).
+
+## Why the forecast monitor is triggered, not scheduled
+
+The forecast trigger's correctness depends on the upstream `ds-storms-pipeline`
+landing the NHC tracks in `storms.nhc_tracks_geo` **before** this monitor reads
+them. A time-based schedule is only a guess at when that finishes (the upstream
+even has a `:30` late-WSP retry). So instead, `nhc_pipeline` runs this monitor as
+a downstream `run_job_task` once its tracks task has completed — event-driven, no
+race. The observational monitor has no such dependency, so it stays on a plain
+daily schedule.
 
 ## Architecture
 
@@ -21,24 +31,27 @@ fallback (they still send via the humdata_email SMTP path).
   `bundle deploy` is only needed when the *job config* (schedule, params,
   libraries, cluster) changes.
 - Each task runs the thin wrapper `databricks/run_monitor_job.py`, which selects
-  the monitor (`fcast`/`obsv`), injects the listmonk creds from the `dsci`
-  secret scope, sets `EMAIL_BACKEND=listmonk` and the run-mode env vars, and
-  shells out to the monitor script. Pipeline code (`pipelines/`, `src/`) stays
-  pure Python and DBX-agnostic — the GHA workflows run the same scripts.
-- Compute: the existing interactive cluster `${var.existing_cluster_id}` (the
-  one ds-storms-pipeline uses), which already carries the `DSCI_AZ_*` DB/blob
-  env vars — including the `*_PROD_*` ones the IMERG raster path reads.
+  the monitor (`fcast`/`obsv`), sets `EMAIL_BACKEND=listmonk` and the run-mode
+  env vars, and shells out to the monitor script. Pipeline code (`pipelines/`,
+  `src/`) stays pure Python and DBX-agnostic — the GHA workflows run the same
+  scripts.
+- **Compute: an ephemeral single-node job cluster per run** (not anyone's
+  personal interactive cluster). It starts bare, so every credential the
+  pipeline reads is injected from the `dsci` secret scope via the cluster's
+  `spark_env_vars`: `DSCI_AZ_*` (DB/blob — dev for NHC tracks, prod for IMERG,
+  consumed by ocha_stratus) and `DSCI_LISTMONK_*` (sender creds, consumed by the
+  listmonk dispatch).
 
 ## Target model — one live deploy, dev on demand
 
-**Don't run two standing deploys.** Two targets scheduled on the same branch
-just fire twice per advisory.
+**Don't run two standing deploys.** Two targets on the same branch just double
+up.
 
 - **`prod`** (default target) is the only normally-deployed bundle. It serves the
-  scheduled runs *and* ad-hoc manual runs (override params per run). Live params:
+  obsv schedule + the triggered fcast runs, plus ad-hoc manual runs. Live params:
   `dry_run=False`, `test_email=False`, `force_alert=False`.
 - **`dev`** is deployed **on demand for feature work**, pointed at a feature
-  branch. Development mode auto-pauses both schedules and defaults to the test
+  branch. Development mode auto-pauses the obsv schedule and defaults to the test
   list, so it never competes with prod. Destroy it when the feature merges.
 
 ## Common commands
@@ -76,9 +89,10 @@ files (`--var test_email=False`). Per run, override with `--params`.
 
 1. Workspace GitHub credentials for this repo (same mechanism as
    ds-storms-pipeline).
-2. Listmonk **sender** config in the `dsci` secret scope (already present —
-   shared with ds-storms-alerts):
-   `DSCI_LISTMONK_BASE_URL`, `DSCI_LISTMONK_API_USERNAME`, `DSCI_LISTMONK_API_KEY`.
+2. The `dsci` secret scope must carry the keys the cluster injects (all already
+   present, shared with the rest of the storms stack): the `DSCI_AZ_*` DB/blob
+   creds and the listmonk **sender** creds (`DSCI_LISTMONK_BASE_URL`,
+   `DSCI_LISTMONK_API_USERNAME`, `DSCI_LISTMONK_API_KEY`).
 3. The listmonk lists + dual-language template must exist on the instance the
    `DSCI_LISTMONK_BASE_URL` points at (run `pipelines/setup_cub_listmonk_lists.py`).
 
@@ -90,19 +104,24 @@ schedule anything. To take the monitors live on Databricks:
 1. **Provision the production listmonk instance** + recreate the lists/template
    and point `dsci/DSCI_LISTMONK_BASE_URL` at it (currently the demo instance).
 2. **Import the real subscribers** to the info/trigger lists.
-3. `databricks bundle deploy -p DEFAULT` — deploys both prod jobs (schedules
-   active in production mode). Confirm `dry_run=False`, `test_email=False`.
-4. Leave the GitHub Actions monitor workflows **disabled** (they're the manual
-   fallback). Re-enabling them while the DBX jobs run would double-fire.
+3. `databricks bundle deploy -p DEFAULT` — deploys both prod jobs (obsv schedule
+   active; fcast trigger-only). Confirm `dry_run=False`, `test_email=False`.
+4. Deploy the matching `ds-storms-pipeline` change so `nhc_pipeline` triggers the
+   prod `fcast_monitor` (point its `cub_fcast_job_id` var at the prod job id).
+5. Leave the GitHub Actions monitor workflows **disabled** (the manual fallback).
+   Re-enabling them while the DBX jobs run would double-fire.
 
-## Gotchas / best practices (from the ds-storms-alerts deploy)
+## Gotchas / best practices (from the ds-storms-alerts/pipeline deploys)
 
 - **Don't set `schedule.pause_status: UNPAUSED` in the resource.** It overrides
-  development mode's auto-pause and makes the `dev` jobs fire on the cron too.
+  development mode's auto-pause and makes the `dev` obsv job fire on the cron too.
   Leave it unset: production mode keeps prod running; development mode pauses dev.
 - **The wrapper must not call `sys.exit()` at the top level.** `spark_python_task`
   treats a top-level `SystemExit` — *even code 0* — as a task failure. The wrapper
   raises an exception only on a non-zero child exit; success returns naturally.
+- **The ephemeral job cluster starts bare.** Every credential the pipeline reads
+  must be in the cluster's `spark_env_vars` (resolved from `dsci`). If a new env
+  var is added to the pipeline, add it there too.
 - **Verify runs from the task logs, not the CLI exit code.** `databricks bundle run`
   can report exit 0 while the task itself failed. Check the run output for the
   monitor's log lines (or `databricks jobs get-run-output <task_run_id>`).

--- a/databricks/run_monitor_job.py
+++ b/databricks/run_monitor_job.py
@@ -1,0 +1,113 @@
+"""DBX entry wrapper for the Cuba hurricane monitors.
+
+The bundle's ``spark_python_task`` passes the job parameters positionally:
+
+    sys.argv[1] = monitor      # "fcast" | "obsv" (which monitor to run)
+    sys.argv[2] = dry_run      # "True" | "False"
+    sys.argv[3] = test_email   # "True" | "False"
+    sys.argv[4] = force_alert  # "True" | "False"
+
+The monitor scripts (pipelines/01_update_fcast_monitor.py /
+02_update_obsv_monitor.py) and src/ stay pure Python — they don't know about
+DBX (the GitHub Actions workflows run the same scripts). This wrapper is the
+only DBX-specific glue and does two things:
+
+1. Inject the listmonk credentials and select the listmonk backend. The reused
+   cluster carries the ``DSCI_AZ_*`` DB/blob env vars (used by ds-storms-
+   pipeline) but NOT the listmonk ones, so we read those from the ``dsci``
+   secret scope and export them, alongside the run-mode env vars the monitor
+   reads at import (``DRY_RUN`` / ``TEST_EMAIL`` / ``FORCE_ALERT``) and
+   ``EMAIL_BACKEND=listmonk`` so dispatch goes through ocha_relay rather than
+   the humdata_email SMTP fallback.
+
+2. Shell out to the monitor script with ``PYTHONPATH`` set to the repo root so
+   ``from src ...`` resolves — under ``source: GIT`` the repo is cloned but not
+   pip-installed, and the scripts live in ``pipelines/`` rather than at the
+   root.
+"""
+
+import os
+import subprocess
+import sys
+
+# monitor selector -> the pure-Python entry script it maps to.
+_MONITOR_SCRIPTS = {
+    "fcast": "pipelines/01_update_fcast_monitor.py",
+    "obsv": "pipelines/02_update_obsv_monitor.py",
+}
+
+
+def _find_script_dir() -> str:
+    """spark_python_task's exec context doesn't always define __file__."""
+    try:
+        return os.path.dirname(os.path.abspath(__file__))  # noqa: F821
+    except NameError:
+        pass
+    if sys.argv and sys.argv[0]:
+        return os.path.dirname(os.path.abspath(sys.argv[0]))
+    return os.getcwd()
+
+
+def _arg(i: int, default: str = "") -> str:
+    return sys.argv[i] if len(sys.argv) > i else default
+
+
+REPO_ROOT = os.path.abspath(os.path.join(_find_script_dir(), ".."))
+
+MONITOR = _arg(1, "fcast")
+DRY_RUN = _arg(2, "True")
+TEST_EMAIL = _arg(3, "True")
+FORCE_ALERT = _arg(4, "False")
+
+if MONITOR not in _MONITOR_SCRIPTS:
+    raise ValueError(
+        f"unknown monitor {MONITOR!r}; expected one of "
+        f"{sorted(_MONITOR_SCRIPTS)}"
+    )
+
+# Listmonk config — absent from the reused cluster's env, pulled from the dsci
+# scope (base URL + sender API creds, so dev/prod can't drift and repointing
+# needs no code edit). Tolerated if missing so a dry-run (no send) still
+# validates DB/blob/plotting; the dispatch only builds the ListmonkClient when
+# actually sending, and will then raise a clear missing-env error.
+from databricks.sdk.runtime import dbutils  # noqa: E402
+
+for _key in (
+    "DSCI_LISTMONK_BASE_URL",
+    "DSCI_LISTMONK_API_USERNAME",
+    "DSCI_LISTMONK_API_KEY",
+):
+    try:
+        os.environ[_key] = dbutils.secrets.get("dsci", _key)
+    except Exception as exc:  # noqa: BLE001
+        print(f"[run_monitor_job] WARNING: dsci/{_key} unavailable ({exc}); "
+              "real sends will fail until it is set.")
+
+# Route email dispatch through listmonk (ocha_relay) rather than the legacy
+# humdata_email SMTP backend.
+os.environ["EMAIL_BACKEND"] = "listmonk"
+os.environ["DRY_RUN"] = DRY_RUN
+os.environ["TEST_EMAIL"] = TEST_EMAIL
+os.environ["FORCE_ALERT"] = FORCE_ALERT
+
+# Make `src` importable for the child process (repo isn't pip-installed here).
+env = dict(os.environ)
+env["PYTHONPATH"] = REPO_ROOT + os.pathsep + env.get("PYTHONPATH", "")
+# Give matplotlib a writable local config/cache dir (the cloned repo lives on
+# the read-only workspace FUSE mount, which it can't use).
+env["MPLCONFIGDIR"] = "/tmp/mplconfig"
+
+cmd = [sys.executable, os.path.join(REPO_ROOT, _MONITOR_SCRIPTS[MONITOR])]
+
+if __name__ == "__main__":
+    print(
+        f"[run_monitor_job] repo_root={REPO_ROOT} monitor={MONITOR} "
+        f"EMAIL_BACKEND=listmonk DRY_RUN={DRY_RUN} TEST_EMAIL={TEST_EMAIL} "
+        f"FORCE_ALERT={FORCE_ALERT}"
+    )
+    rc = subprocess.run(cmd, cwd=REPO_ROOT, env=env, check=False).returncode
+    # DBX treats a top-level sys.exit()/SystemExit (even code 0) as a task
+    # failure. Raise only on non-zero; let success return naturally.
+    if rc != 0:
+        raise RuntimeError(f"{_MONITOR_SCRIPTS[MONITOR]} exited with code {rc}")
+    print("[run_monitor_job] OK")

--- a/databricks/run_monitor_job.py
+++ b/databricks/run_monitor_job.py
@@ -27,8 +27,10 @@ only DBX-specific glue and does two things:
 """
 
 import os
+import shutil
 import subprocess
 import sys
+import tempfile
 
 # monitor selector -> the pure-Python entry script it maps to.
 _MONITOR_SCRIPTS = {
@@ -74,33 +76,42 @@ os.environ["DRY_RUN"] = DRY_RUN
 os.environ["TEST_EMAIL"] = TEST_EMAIL
 os.environ["FORCE_ALERT"] = FORCE_ALERT
 
-# Make `src` importable for the child process (repo isn't pip-installed here).
+# Under source: GIT the repo is cloned onto the workspace FUSE mount (wsfs).
+# Importing Python packages whose directories live on wsfs is unreliable: the
+# import machinery probes several candidate filenames per module
+# (__init__.cpython-*.so, __init__.py, ...) and wsfs raises a hard filesystem
+# error for the non-existent candidates instead of a clean "not found",
+# intermittently breaking `from src ...` (and likewise breaks __pycache__ writes
+# and matplotlib's cwd scan). So copy the Python sources onto local disk and
+# import/run from there — wsfs is then off the import path and the cwd entirely.
+# The monitors read all their data from blob/DB, so src + pipelines is the whole
+# footprint (templates live under src/).
+LOCAL_ROOT = os.path.join(
+    "/local_disk0" if os.path.isdir("/local_disk0") else tempfile.gettempdir(),
+    "cub_monitor_run",
+)
+for _sub in ("src", "pipelines"):
+    shutil.copytree(
+        os.path.join(REPO_ROOT, _sub),
+        os.path.join(LOCAL_ROOT, _sub),
+        dirs_exist_ok=True,
+        ignore=shutil.ignore_patterns("__pycache__", "*.pyc"),
+    )
+
 env = dict(os.environ)
-env["PYTHONPATH"] = REPO_ROOT + os.pathsep + env.get("PYTHONPATH", "")
-# Give matplotlib a writable local config/cache dir (the cloned repo lives on
-# the read-only workspace FUSE mount, which it can't use).
+env["PYTHONPATH"] = LOCAL_ROOT + os.pathsep + env.get("PYTHONPATH", "")
+# matplotlib needs a writable config/cache dir (and must not land on wsfs).
 env["MPLCONFIGDIR"] = "/tmp/mplconfig"
-# Don't write __pycache__/*.pyc next to the imported sources: under source: GIT
-# the repo lives on the workspace FUSE mount (wsfs), which rejects __pycache__
-# ("operation not supported") and would otherwise break every `from src ...`.
-env["PYTHONDONTWRITEBYTECODE"] = "1"
 
-cmd = [sys.executable, os.path.join(REPO_ROOT, _MONITOR_SCRIPTS[MONITOR])]
-
-# Run from a normal local dir, NOT the cloned repo (which is on the wsfs FUSE
-# mount). Libraries that scan the cwd on init — e.g. matplotlib looking for a
-# ./matplotlibrc — hit a wsfs filesystem error there. The monitors import via
-# PYTHONPATH and use __file__-based paths, so they don't depend on cwd; /tmp is
-# also writable for any incidental temp files, unlike the read-only mount.
-RUN_CWD = "/tmp"
+cmd = [sys.executable, os.path.join(LOCAL_ROOT, _MONITOR_SCRIPTS[MONITOR])]
 
 if __name__ == "__main__":
     print(
-        f"[run_monitor_job] repo_root={REPO_ROOT} monitor={MONITOR} "
-        f"EMAIL_BACKEND=listmonk DRY_RUN={DRY_RUN} TEST_EMAIL={TEST_EMAIL} "
-        f"FORCE_ALERT={FORCE_ALERT}"
+        f"[run_monitor_job] repo_root={REPO_ROOT} local_root={LOCAL_ROOT} "
+        f"monitor={MONITOR} EMAIL_BACKEND=listmonk DRY_RUN={DRY_RUN} "
+        f"TEST_EMAIL={TEST_EMAIL} FORCE_ALERT={FORCE_ALERT}"
     )
-    rc = subprocess.run(cmd, cwd=RUN_CWD, env=env, check=False).returncode
+    rc = subprocess.run(cmd, cwd=LOCAL_ROOT, env=env, check=False).returncode
     # DBX treats a top-level sys.exit()/SystemExit (even code 0) as a task
     # failure. Raise only on non-zero; let success return naturally.
     if rc != 0:

--- a/databricks/run_monitor_job.py
+++ b/databricks/run_monitor_job.py
@@ -75,6 +75,10 @@ os.environ["EMAIL_BACKEND"] = "listmonk"
 os.environ["DRY_RUN"] = DRY_RUN
 os.environ["TEST_EMAIL"] = TEST_EMAIL
 os.environ["FORCE_ALERT"] = FORCE_ALERT
+# Headless: ocha_relay's send_campaign would otherwise prompt for typed
+# confirmation and raise EOFError here. Skip the prompt so the job can send
+# unattended (a local/manual run, which does not set this, stays interactive).
+os.environ["LISTMONK_SKIP_CONFIRMATION"] = "true"
 
 # Under source: GIT the repo is cloned onto the workspace FUSE mount (wsfs).
 # Importing Python packages whose directories live on wsfs is unreliable: the

--- a/databricks/run_monitor_job.py
+++ b/databricks/run_monitor_job.py
@@ -12,13 +12,13 @@ The monitor scripts (pipelines/01_update_fcast_monitor.py /
 DBX (the GitHub Actions workflows run the same scripts). This wrapper is the
 only DBX-specific glue and does two things:
 
-1. Inject the listmonk credentials and select the listmonk backend. The reused
-   cluster carries the ``DSCI_AZ_*`` DB/blob env vars (used by ds-storms-
-   pipeline) but NOT the listmonk ones, so we read those from the ``dsci``
-   secret scope and export them, alongside the run-mode env vars the monitor
-   reads at import (``DRY_RUN`` / ``TEST_EMAIL`` / ``FORCE_ALERT``) and
-   ``EMAIL_BACKEND=listmonk`` so dispatch goes through ocha_relay rather than
-   the humdata_email SMTP fallback.
+1. Select the listmonk email backend and set the run-mode env vars the monitor
+   reads at import (``EMAIL_BACKEND=listmonk`` so dispatch goes through
+   ocha_relay rather than the humdata_email SMTP fallback, plus
+   ``DRY_RUN`` / ``TEST_EMAIL`` / ``FORCE_ALERT``). The actual credentials
+   (``DSCI_AZ_*`` DB/blob, ``DSCI_LISTMONK_*`` sender) are NOT set here — the
+   job cluster injects them from the ``dsci`` secret scope via spark_env_vars
+   (see databricks.yml), so they are already in the environment.
 
 2. Shell out to the monitor script with ``PYTHONPATH`` set to the repo root so
    ``from src ...`` resolves — under ``source: GIT`` the repo is cloned but not
@@ -65,26 +65,10 @@ if MONITOR not in _MONITOR_SCRIPTS:
         f"{sorted(_MONITOR_SCRIPTS)}"
     )
 
-# Listmonk config — absent from the reused cluster's env, pulled from the dsci
-# scope (base URL + sender API creds, so dev/prod can't drift and repointing
-# needs no code edit). Tolerated if missing so a dry-run (no send) still
-# validates DB/blob/plotting; the dispatch only builds the ListmonkClient when
-# actually sending, and will then raise a clear missing-env error.
-from databricks.sdk.runtime import dbutils  # noqa: E402
-
-for _key in (
-    "DSCI_LISTMONK_BASE_URL",
-    "DSCI_LISTMONK_API_USERNAME",
-    "DSCI_LISTMONK_API_KEY",
-):
-    try:
-        os.environ[_key] = dbutils.secrets.get("dsci", _key)
-    except Exception as exc:  # noqa: BLE001
-        print(f"[run_monitor_job] WARNING: dsci/{_key} unavailable ({exc}); "
-              "real sends will fail until it is set.")
-
 # Route email dispatch through listmonk (ocha_relay) rather than the legacy
-# humdata_email SMTP backend.
+# humdata_email SMTP backend. The DSCI_LISTMONK_* / DSCI_AZ_* credentials are
+# supplied by the job cluster's spark_env_vars (resolved from the dsci secret
+# scope), so they are already present in the environment here.
 os.environ["EMAIL_BACKEND"] = "listmonk"
 os.environ["DRY_RUN"] = DRY_RUN
 os.environ["TEST_EMAIL"] = TEST_EMAIL

--- a/databricks/run_monitor_job.py
+++ b/databricks/run_monitor_job.py
@@ -80,6 +80,10 @@ env["PYTHONPATH"] = REPO_ROOT + os.pathsep + env.get("PYTHONPATH", "")
 # Give matplotlib a writable local config/cache dir (the cloned repo lives on
 # the read-only workspace FUSE mount, which it can't use).
 env["MPLCONFIGDIR"] = "/tmp/mplconfig"
+# Don't write __pycache__/*.pyc next to the imported sources: under source: GIT
+# the repo lives on the workspace FUSE mount (wsfs), which rejects __pycache__
+# ("operation not supported") and would otherwise break every `from src ...`.
+env["PYTHONDONTWRITEBYTECODE"] = "1"
 
 cmd = [sys.executable, os.path.join(REPO_ROOT, _MONITOR_SCRIPTS[MONITOR])]
 

--- a/databricks/run_monitor_job.py
+++ b/databricks/run_monitor_job.py
@@ -87,13 +87,20 @@ env["PYTHONDONTWRITEBYTECODE"] = "1"
 
 cmd = [sys.executable, os.path.join(REPO_ROOT, _MONITOR_SCRIPTS[MONITOR])]
 
+# Run from a normal local dir, NOT the cloned repo (which is on the wsfs FUSE
+# mount). Libraries that scan the cwd on init — e.g. matplotlib looking for a
+# ./matplotlibrc — hit a wsfs filesystem error there. The monitors import via
+# PYTHONPATH and use __file__-based paths, so they don't depend on cwd; /tmp is
+# also writable for any incidental temp files, unlike the read-only mount.
+RUN_CWD = "/tmp"
+
 if __name__ == "__main__":
     print(
         f"[run_monitor_job] repo_root={REPO_ROOT} monitor={MONITOR} "
         f"EMAIL_BACKEND=listmonk DRY_RUN={DRY_RUN} TEST_EMAIL={TEST_EMAIL} "
         f"FORCE_ALERT={FORCE_ALERT}"
     )
-    rc = subprocess.run(cmd, cwd=REPO_ROOT, env=env, check=False).returncode
+    rc = subprocess.run(cmd, cwd=RUN_CWD, env=env, check=False).returncode
     # DBX treats a top-level sys.exit()/SystemExit (even code 0) as a task
     # failure. Raise only on non-zero; let success return naturally.
     if rc != 0:

--- a/docs/decisions/0000-use-markdown-architectural-decision-records.md
+++ b/docs/decisions/0000-use-markdown-architectural-decision-records.md
@@ -1,0 +1,44 @@
+---
+status: "accepted"
+date: 2026-06-18
+decision-makers: [Zack]
+---
+
+# Use Markdown Architectural Decision Records
+
+## Context and Problem Statement
+
+This project makes technical decisions whose rationale is easy to lose — compute
+models, data-source switches, triggering mechanisms, service and dependency
+choices. Today that reasoning is scattered across commit messages, PR threads,
+and code comments, or recorded nowhere, so the *rejected alternatives* and the
+*why* disappear. How should we record significant decisions so they survive for
+future maintainers (and for Claude)?
+
+## Considered Options
+
+* MADR (Markdown Any Decision Records)
+* Another ADR template (e.g. Nygard, Tyree & Akerman)
+* No formal records — status quo (commit messages / PR descriptions only)
+
+## Decision Outcome
+
+Chosen option: "MADR", because it is lightweight Markdown that lives in the repo
+next to the code, and — unlike a commit message — it captures the considered
+options and their trade-offs, not just the outcome. Records live in
+`docs/decisions/`; new ones copy `template.md`. Scope is kept deliberately narrow
+(see `CLAUDE.md`): only decisions with real trade-offs get an ADR, so the
+practice stays non-intrusive.
+
+### Consequences
+
+* Good, because the rationale and the rejected alternatives are preserved where
+  people will look for them.
+* Good, because it is low-ceremony — a short Markdown file per decision.
+* Bad, because it adds a small step when making a significant decision; mitigated
+  by recording only decisions a maintainer would later question.
+
+## More Information
+
+* MADR: <https://adr.github.io/madr/>
+* Adapted from developmentseed/stac-map's ADR 0000.

--- a/docs/decisions/0001-run-monitors-as-databricks-jobs-on-ephemeral-clusters.md
+++ b/docs/decisions/0001-run-monitors-as-databricks-jobs-on-ephemeral-clusters.md
@@ -1,0 +1,104 @@
+---
+status: "accepted"
+date: 2026-06-18
+decision-makers: [Zack]
+consulted: [Tristan]
+---
+
+# Run the Cuba hurricane monitors as Databricks jobs on ephemeral clusters
+
+## Context and Problem Statement
+
+The two monitors (forecast, observational) ran on GitHub Actions cron, sending
+email via the humdata_email SMTP path. With email dispatch moving to listmonk and
+the rest of the storms stack (ds-storms-pipeline, ds-storms-alerts) already on
+Databricks — where GitHub Actions trigger latency had also degraded — we want to
+run the monitors on Databricks too. How should they be defined, deployed, and on
+what compute?
+
+## Decision Drivers
+
+* Align with the storms stack already on Databricks.
+* Reproducible and **person-independent** — not tied to an individual's cluster.
+* Reasonable cost; the monitors are plain Python, not Spark.
+* Pipeline code stays DBX-agnostic, so the GitHub Actions fallback can run the
+  exact same scripts.
+* The forecast monitor drives anticipatory action with **multi-day lead times**,
+  so per-run startup latency is not operationally critical.
+
+## Considered Options
+
+Deployment: a Databricks Asset Bundle (DAB) with `source: GIT` (clone the repo at
+run time → push-to-ship) vs `source: WORKSPACE` (sync files at deploy).
+
+Compute, for running the jobs:
+
+* Ephemeral single-node job cluster per run
+* Warm always-on all-purpose cluster with libraries pre-installed
+* Instance pool
+* Serverless jobs compute
+
+## Decision Outcome
+
+A DAB defines two jobs; each task is a thin wrapper (`databricks/run_monitor_job.py`)
+that selects the listmonk backend and shells out to the unchanged monitor script.
+`source: GIT` is used (push the branch to ship code; `bundle deploy` only for job
+config). Each job runs on an **ephemeral single-node job cluster**, with the
+`DSCI_AZ_*` and `DSCI_LISTMONK_*` credentials injected from the `dsci` secret
+scope via `spark_env_vars`.
+
+Chosen because: the multi-day AA lead times make the ~15–20 min per-run startup
+(mostly library install) operationally negligible, while ephemeral clusters keep
+the reproducible / person-independent / zero-idle-cost properties and match
+ds-storms-pipeline's prod compute. A warm cluster would be faster per run but was
+rejected (see cons). `source: GIT` is preferred over `source: WORKSPACE` for the
+push-to-ship workflow; UI browsability is met separately by a Git folder under
+`/Repos`, independent of how the jobs run.
+
+### Consequences
+
+* Good — reproducible, person-independent, no idle cost; library versions track
+  `requirements.txt`; pipeline code stays pure Python (GHA fallback unaffected).
+* Bad — ~15–20 min startup per run (dominated by library install on a bare
+  cluster), which also slows dev iteration. Optimization options are documented
+  in `databricks/README.md` ("Startup time").
+* Implementation note — importing Python packages off the workspace FUSE mount
+  (wsfs) is unreliable, so the wrapper copies `src` + `pipelines` to
+  `/local_disk0` and runs from there.
+
+### Confirmation
+
+Both monitors were validated green (`TERMINATED SUCCESS`) via `dev`-target
+dry-runs on the ephemeral cluster: DB read, library resolution, listmonk-backend
+selection, and DRY_RUN simulation all worked end to end.
+
+## Pros and Cons of the Options
+
+### Ephemeral single-node job cluster (chosen)
+
+* Good — isolated, reproducible, person-independent, zero idle cost.
+* Bad — pays the full ~15 min library install every run.
+
+### Warm all-purpose cluster, libraries pre-installed
+
+* Good — fastest per run (libs already there).
+* Bad — single-user ACLs (or a shared service principal to manage); idle cost;
+  mutable shared state that other users/restarts can break; library set lives
+  off-bundle and drifts from `requirements.txt`. Acceptable only as a dev-only
+  convenience.
+
+### Instance pool
+
+* Neutral — shaves the ~4 min VM boot, not the ~15 min install; low ROI alone.
+
+### Serverless jobs compute
+
+* Good — fast start, env caching, scale-to-zero.
+* Bad — needs serverless enabled, networking to reach Azure Postgres/blob, and a
+  check that the geo stack installs cleanly; unproven for this stack here.
+
+## More Information
+
+* `databricks/README.md` — operations, gotchas, and startup-time optimizations.
+* Forecast triggering is a separate decision: see
+  `0002-trigger-forecast-monitor-from-upstream-pipeline.md`.

--- a/docs/decisions/0002-trigger-forecast-monitor-from-upstream-pipeline.md
+++ b/docs/decisions/0002-trigger-forecast-monitor-from-upstream-pipeline.md
@@ -61,7 +61,7 @@ sides for no clear gain).
 
 * The cub side is ready (the `fcast_monitor` job has no schedule). The upstream
   `run_job_task` is a follow-up in `ds-storms-pipeline`, to be wired against the
-  prod job id at go-live.
+  prod job id at go-live — tracked in OCHA-DAP/ds-storms-pipeline#33.
 * Compute/deployment model: see
   `0001-run-monitors-as-databricks-jobs-on-ephemeral-clusters.md`.
 * `databricks/README.md` — "Why the forecast monitor is triggered, not scheduled".

--- a/docs/decisions/0002-trigger-forecast-monitor-from-upstream-pipeline.md
+++ b/docs/decisions/0002-trigger-forecast-monitor-from-upstream-pipeline.md
@@ -1,0 +1,67 @@
+---
+status: "accepted"
+date: 2026-06-18
+decision-makers: [Zack]
+consulted: [Tristan]
+---
+
+# Trigger the forecast monitor from the upstream ds-storms-pipeline
+
+## Context and Problem Statement
+
+The forecast monitor's correctness depends on the NHC tracks being present in
+Postgres (`storms.nhc_tracks_geo`), which the upstream `ds-storms-pipeline` job
+lands. If the monitor runs before the tracks arrive, it reads stale or missing
+data. The observational monitor has no such upstream dependency. How should the
+forecast monitor be triggered on Databricks?
+
+## Decision Drivers
+
+* Correctness — do not read before the tracks have landed.
+* Avoid a time-guess; the upstream cadence varies and it has a `:30` late-WSP
+  retry, so "30 min after the advisory" is not reliable.
+* Keep the observational monitor simple (it has no data dependency).
+
+## Considered Options
+
+* Schedule the forecast monitor ~30 min after each advisory (status quo; what
+  ds-storms-alerts does).
+* The upstream `ds-storms-pipeline` triggers it via a downstream `run_job_task`
+  once its tracks task completes.
+* The Postgres database triggers it on row insert.
+
+## Decision Outcome
+
+The upstream `nhc_pipeline` job in `ds-storms-pipeline` runs the cub
+`fcast_monitor` as a downstream `run_job_task`, after its tracks task. The cub
+`fcast_monitor` therefore has **no schedule of its own**. The observational
+monitor keeps a plain daily schedule.
+
+Chosen because it is event-driven — the monitor runs exactly when its data is
+ready, with no race. A schedule is only a guess at when the upstream finishes. A
+database trigger is not natively available: Databricks job triggers are cron,
+file-arrival (Unity Catalog volume / external location), or table-update (UC
+Delta tables), and our data lands in an **external Azure Postgres**, which is
+none of those (a marker-file + file-arrival shim would be extra plumbing on both
+sides for no clear gain).
+
+### Consequences
+
+* Good — the forecast monitor runs only after the tracks have landed; no time
+  guess, and it naturally follows the upstream cadence.
+* Bad — couples the two repos/bundles: `ds-storms-pipeline` must reference the
+  cub **prod** `fcast_monitor` job id, which does not exist until the cub bundle
+  is deployed to prod. The wiring lives in the other repo and is therefore
+  **deferred to go-live** (tracked as a follow-up issue on ds-storms-pipeline).
+* Bad — the upstream's `:30` retry run could fire a second monitor run per
+  advisory; mitigated by `max_concurrent_runs: 1` and the once-per-issuance
+  email scoping.
+
+## More Information
+
+* The cub side is ready (the `fcast_monitor` job has no schedule). The upstream
+  `run_job_task` is a follow-up in `ds-storms-pipeline`, to be wired against the
+  prod job id at go-live.
+* Compute/deployment model: see
+  `0001-run-monitors-as-databricks-jobs-on-ephemeral-clusters.md`.
+* `databricks/README.md` — "Why the forecast monitor is triggered, not scheduled".

--- a/docs/decisions/0003-listmonk-as-default-email-backend.md
+++ b/docs/decisions/0003-listmonk-as-default-email-backend.md
@@ -1,0 +1,58 @@
+---
+status: "accepted"
+date: 2026-06-19
+decision-makers: [Zack]
+consulted: [Tristan]
+---
+
+# Make listmonk the default email backend
+
+## Context and Problem Statement
+
+`EMAIL_BACKEND` selects the email system: `listmonk` (ocha_relay campaigns, the
+path we're moving to) or `humdata_email` (the legacy AWS-SES SMTP path). It first
+shipped defaulting to `humdata_email` so merging was behaviour-neutral. But
+listmonk is now the intended primary path, and defaulting to the legacy system is
+backwards. What should the default be, and what role does humdata_email keep?
+
+## Decision Drivers
+
+* Listmonk is the primary path going forward; the default should reflect that.
+* We don't want the legacy SMTP path used implicitly.
+* The GitHub Actions monitor workflows are being retired in favour of the
+  Databricks jobs (see [[0001-run-monitors-as-databricks-jobs-on-ephemeral-clusters]]).
+
+## Considered Options
+
+* Keep `humdata_email` as the default; listmonk opt-in.
+* Make `listmonk` the default; `humdata_email` only when explicitly selected.
+* Automatic failover from listmonk to humdata_email on error.
+
+## Decision Outcome
+
+Default `EMAIL_BACKEND=listmonk`. `humdata_email` stays in the code as a **manual
+escape hatch**, used only by explicitly setting `EMAIL_BACKEND=humdata_email` in
+an environment that has the `DSCI_AWS_EMAIL_*` creds — and is deliberately **not**
+wired into the GitHub Actions workflows. No automatic failover (a silent switch
+between sending systems is worse than a visible failure).
+
+### Consequences
+
+* Good — the primary path is the default; the legacy system is never used
+  implicitly.
+* Good — still safe on merge: nothing auto-runs (monitor crons disabled, no
+  bundle deployed), so flipping the default sends nothing by merging.
+* Bad — the GHA monitor workflows are no longer a working fallback: with listmonk
+  the default and no listmonk creds in GitHub, re-enabling one would fail rather
+  than send via SMTP. Accepted — those workflows are retired; the SMTP fallback
+  is the manual escape hatch above.
+* The automated Databricks path sends unattended because its wrapper sets
+  `LISTMONK_SKIP_CONFIRMATION=true`; local/manual runs keep ocha_relay's
+  interactive typed-confirmation (it would otherwise `EOFError` headless and
+  silently not send).
+
+## More Information
+
+* Backend routing: `src/email/backends.py` (selects at import on `EMAIL_BACKEND`).
+* Unsubscribe handling for listmonk recipients:
+  [[0004-suppress-unsubscribe-via-subscriber-attribute]].

--- a/docs/decisions/0004-suppress-unsubscribe-via-subscriber-attribute.md
+++ b/docs/decisions/0004-suppress-unsubscribe-via-subscriber-attribute.md
@@ -1,0 +1,60 @@
+---
+status: "accepted"
+date: 2026-06-19
+decision-makers: [Zack]
+consulted: [Tristan, CHD listmonk team]
+---
+
+# Suppress the unsubscribe link via a per-subscriber attribute
+
+## Context and Problem Statement
+
+Listmonk campaigns inject an unsubscribe link by default. The Cuba hurricane
+trigger/activation emails are **must-deliver** alerts to government and agency
+contacts; we don't want a recipient to silently unsubscribe and miss an
+activation. How do we suppress the unsubscribe link for these recipients?
+
+## Decision Drivers
+
+* Trigger/activation emails are operational, must-deliver.
+* Avoid heavy template surgery (we *use* the shared campaign template and inject
+  content into it — we don't want to fork its design).
+* Recipients are operational contacts, not a general public newsletter audience.
+
+## Considered Options
+
+* Accept the unsubscribe link (recipients can opt out).
+* Edit the template to hard-remove the unsubscribe link.
+* Use listmonk's transactional API for triggers (no unsubscribe, bypasses
+  subscription status).
+* Per-subscriber attribute `type=mailing_list` — the campaign template already
+  renders the unsubscribe link only when `attribs.type != "mailing_list"`.
+
+## Decision Outcome
+
+Set `attribs={"type": "mailing_list"}` on subscribers at import
+(`pipelines/setup_cub_listmonk_lists.py`). The campaign template already gates the
+unsubscribe link on `attribs.type != "mailing_list"`, so for these subscribers
+the link is omitted — **no template change**, and it follows the CHD listmonk
+team's existing convention for mailing-list-type recipients.
+
+### Consequences
+
+* Good — no template surgery; recipients can't self-unsubscribe from the alerts;
+  the gate is per-subscriber, so a non-`mailing_list` subscriber still gets a link.
+* Bad — `attribs` is **global per subscriber**, not per-list: the flag suppresses
+  the unsubscribe link in *every* email that person receives on the shared
+  listmonk instance (wherever a template checks it), not just Cuba's. Accepted
+  because it's set only on new Cuba recipients, who are only on Cuba lists.
+* Bad — the attribute is set only on the **new-subscriber** import path; a contact
+  who already exists on the instance keeps their existing attribs (and so would
+  still see the link). Accepted: overlap with other projects is negligible, and
+  new-recipient scope was the chosen bound.
+
+## More Information
+
+* Mechanism: template footer conditional in
+  `src/email/templates/listmonk/basecampaign_dual_language.html`; attribute set in
+  the POST path of `import_subscribers`.
+* Default backend / send behaviour:
+  [[0003-listmonk-as-default-email-backend]].

--- a/docs/decisions/template.md
+++ b/docs/decisions/template.md
@@ -1,0 +1,52 @@
+---
+# Configuration of this file: https://adr.github.io/madr/
+status: "{proposed | accepted | rejected | deprecated | superseded by ADR-NNNN}"
+date: { YYYY-MM-DD when the decision was last updated }
+decision-makers: { list everyone involved in the decision }
+consulted: { optional — subject-matter experts consulted (two-way) }
+informed: { optional — kept up to date (one-way) }
+---
+
+# {short title of the problem and its chosen solution}
+
+## Context and Problem Statement
+
+{2–4 sentences. What forces are at play, and what question are we answering?}
+
+## Decision Drivers (optional)
+
+* {driver / constraint 1}
+* {driver / constraint 2}
+
+## Considered Options
+
+* {option 1}
+* {option 2}
+* {option 3}
+
+## Decision Outcome
+
+Chosen option: "{option}", because {justification — e.g. resolves a driver,
+acceptable trade-offs, lowest risk}.
+
+### Consequences
+
+* Good, because {positive consequence}
+* Bad, because {negative consequence / cost we accept}
+
+### Confirmation (optional)
+
+{How we know the decision was implemented correctly — a test, a successful run, a
+review.}
+
+## Pros and Cons of the Options (optional)
+
+### {option 1}
+
+* Good, because {…}
+* Neutral, because {…}
+* Bad, because {…}
+
+## More Information (optional)
+
+{Links, related ADRs (supersedes / superseded by), follow-ups left open.}

--- a/src/email/listmonk_emails.py
+++ b/src/email/listmonk_emails.py
@@ -29,6 +29,7 @@ from src.constants import (
     LISTMONK_LISTS,
     LISTMONK_PROJECT_TAG,
     TEST_EMAIL,
+    _parse_bool_env,
 )
 from src.email.plotting import get_plot_blob_name
 from src.email.send_emails import prepare_email_data
@@ -152,10 +153,15 @@ def _send_campaign(
         list_ids=[_resolve_list_id(client, list_type)],
         template_id=_resolve_template_id(),
     )
-    # Use ocha_relay's interactive safe-send (prompts to confirm the campaign
-    # name) rather than skip_confirmation, so nothing sends without approval.
-    # An automated/cron path will need an explicit skip override later.
-    client.send_campaign(cid)
+    # Confirmation mode: by default ocha_relay's safe-send prompts the caller to
+    # type the campaign name before sending (good for local/manual runs). A
+    # headless run has no stdin and would hit EOFError on that prompt, so the
+    # automated path (the Databricks wrapper sets LISTMONK_SKIP_CONFIRMATION=true)
+    # skips it. Unset (local/manual) keeps the interactive confirmation.
+    skip_confirmation = _parse_bool_env(
+        "LISTMONK_SKIP_CONFIRMATION", default=False
+    )
+    client.send_campaign(cid, skip_confirmation=skip_confirmation)
     logger.info(f"Sent listmonk {kind} campaign {cid} for {monitor_id}")
 
 

--- a/src/email/plotting.py
+++ b/src/email/plotting.py
@@ -644,9 +644,8 @@ def create_map_plot_figure(
     df_tracks = nhc.load_recent_glb_nhc(fcast_obsv=fcast_obsv)
 
     if FORCE_ALERT:
-        df_dummy_tracks = create_dummy_storm_tracks(
-            df_tracks, fcast_obsv=fcast_obsv
-        )
+        # The helper loads Rafael (2024) from the DB itself (see its docstring).
+        df_dummy_tracks = create_dummy_storm_tracks(fcast_obsv=fcast_obsv)
         df_tracks = pd.concat([df_tracks, df_dummy_tracks], ignore_index=True)
 
     if fcast_obsv == "fcast":

--- a/src/email/utils.py
+++ b/src/email/utils.py
@@ -47,70 +47,71 @@ TEMPLATES_DIR = Path(os.path.dirname(os.path.abspath(__file__))) / "templates"
 STATIC_DIR = Path(os.path.dirname(os.path.abspath(__file__))) / "static"
 
 
-def create_dummy_storm_tracks(
-    df_tracks: pd.DataFrame, fcast_obsv: str
-) -> pd.DataFrame:
-    """Create dummy storm tracks based on Hurricane Rafael data but with test IDs.
+def create_dummy_storm_tracks(fcast_obsv: str) -> pd.DataFrame:
+    """Build dummy storm tracks from Hurricane Rafael (al182024) for FORCE_ALERT
+    testing, re-stamped with the test ATCF id and shifted to
+    MONITORING_START_DATE.
+
+    Rafael is a 2024-season storm, so its tracks are loaded explicitly from the
+    2024 season here — the live monitor's loads are scoped to the current season
+    and no longer contain it. Filtering on the unique ATCF id (not the name) also
+    sidesteps the DB storing the name as "RAFAEL". This is only called by the
+    FORCE_ALERT plot path (create_map_plot_figure); it does not affect normal
+    monitoring.
 
     Args:
-        fcast_obsv: Whether to create forecast or observation tracks
+        fcast_obsv: "fcast" or "obsv" — which kind of track to build.
 
     Returns:
-        DataFrame with tracks data modified to match dummy storm monitoring data
+        DataFrame of dummy track points (id = TEST_ATCF_ID).
     """
-    # Use Hurricane Rafael as the base data
-    dummy_id = "al182024"
-    dummy_name = "Rafael"
-    # al182024_fcast_2024-11-04T21:00:00
+    dummy_id = "al182024"  # Hurricane Rafael (2024 Atlantic season)
+    df_tracks = nhc.load_recent_glb_nhc(fcast_obsv=fcast_obsv, season=2024)
+    df_tracks = df_tracks[df_tracks["id"] == dummy_id].copy()
 
     if fcast_obsv == "obsv":
         from src.constants import THRESHS
 
-        dummy_track = df_tracks[
-            (df_tracks["id"] == dummy_id) & (df_tracks["name"] == dummy_name)
-        ].copy()
-
         # Sort by time to ensure proper chronological order
-        dummy_track = dummy_track.sort_values("lastUpdate")
+        dummy_track = df_tracks.sort_values("lastUpdate")
 
         # Replace 100-knot values with 105 knots to create threshold crossing
         dummy_track.loc[dummy_track["intensity"] == 100, "intensity"] = 105
 
-        # Find first point where wind crosses observation threshold (105 knots)
+        # Keep points up to the first observation-threshold crossing
         obs_threshold = THRESHS["obsv"]["s"]  # 105 knots
-        threshold_crossed_idx = dummy_track[
+        crossed = dummy_track[
             dummy_track["intensity"] >= obs_threshold
         ].index
-
-        if len(threshold_crossed_idx) > 0:
-            # Include only points up to first threshold crossing
-            first_crossing_idx = threshold_crossed_idx[0]
-            dummy_track = dummy_track.loc[:first_crossing_idx]
+        if len(crossed) > 0:
+            dummy_track = dummy_track.loc[: crossed[0]]
 
         # Shift timestamps to start from MONITORING_START_DATE
         min_time = min(dummy_track["lastUpdate"])
-        diff_from_min = dummy_track["lastUpdate"] - min_time
-        dummy_track["lastUpdate"] = MONITORING_START_DATE + diff_from_min
+        dummy_track["lastUpdate"] = MONITORING_START_DATE + (
+            dummy_track["lastUpdate"] - min_time
+        )
 
     if fcast_obsv == "fcast":
-
+        # Use an issuance that exists in the DB (6-hourly synoptic times); the
+        # old hardcoded 21:00 advisory time predates the DB data source.
         target_track_time = datetime(
-            2024, 11, 4, 21, 0, 0, tzinfo=timezone.utc
+            2024, 11, 4, 18, 0, 0, tzinfo=timezone.utc
         )
         dummy_track = df_tracks[
-            (df_tracks["id"] == dummy_id)
-            & (df_tracks["name"] == dummy_name)
-            & (df_tracks["issuance"] == target_track_time)
+            df_tracks["issuance"] == target_track_time
         ].copy()
-        # Calculate lead time between issuance and validTime
+
+        # Re-stamp the issuance to MONITORING_START_DATE, preserving lead times
         lt = dummy_track["validTime"] - dummy_track["issuance"]
         dummy_track["issuance"] = MONITORING_START_DATE
         dummy_track["validTime"] = dummy_track["issuance"] + lt
 
-        # Inject maxwind value of 125 where lead time = 2 days (action)
-        dummy_track.loc[lt == pd.Timedelta(days=2, hours=9), "maxwind"] = 125
-        # Inject readiness activation
-        dummy_track.loc[lt == pd.Timedelta(days=4, hours=21), "maxwind"] = 125
+        # Force a triggering wind at the forecast points nearest the action and
+        # readiness lead times (robust to the actual lead-time grid).
+        for target in (pd.Timedelta(days=2), pd.Timedelta(days=4)):
+            if len(lt):
+                dummy_track.loc[(lt - target).abs().idxmin(), "maxwind"] = 125
 
     dummy_track["id"] = TEST_ATCF_ID
     return dummy_track


### PR DESCRIPTION
## What

Run the two Cuba hurricane monitors as **Databricks jobs** (Databricks Asset Bundle), as the production vehicle for the listmonk email backend. Follows the `ds-storms-alerts` / `ds-storms-pipeline` pattern.

> **Stacked on #42 (listmonk).** Base is `listmonk`; this will retarget to `main` once #42 merges. Review the diff here for just the Databricks work.

## How

- **`databricks.yml`** — one bundle, two jobs: `fcast_monitor` (trigger-only, no schedule) and `obsv_monitor` (daily `15 17 * * *`). `prod` (default, real audience) + `dev` (auto-paused, test list) targets. Run-mode flags (`dry_run`/`test_email`/`force_alert`) are bundle variables wired to job params.
- **`databricks/run_monitor_job.py`** — thin wrapper: selects `EMAIL_BACKEND=listmonk`, copies `src`+`pipelines` to local disk (off the wsfs mount), shells out to the unchanged monitor scripts. Pipeline code stays pure Python (GHA fallback runs the same scripts).
- **Compute** — ephemeral single-node job clusters; `DSCI_AZ_*` + `DSCI_LISTMONK_*` injected from the `dsci` secret scope via `spark_env_vars`.
- **`src/email/utils.py`** — tolerate an unset `DSCI_AWS_EMAIL_PORT` at import (the listmonk path doesn't carry AWS-email creds; completes the listmonk/AWS decoupling).
- **Docs** — `databricks/README.md` (ops/gotchas/startup), ADRs (`docs/decisions/0001`, `0002`), and a project `CLAUDE.md` adopting the ADR practice.

## Validated

Both monitors run **green** (`TERMINATED SUCCESS`) via `dev`-target dry-runs on the ephemeral cluster: DB read, library resolution, listmonk-backend selection, DRY_RUN simulation. Not yet exercised (data-gated, no qualifying storm now): IMERG raster read, plot generation, and the actual listmonk send.

## ⚠️ Nothing fires on merge

Default `EMAIL_BACKEND=humdata_email`; the GHA monitor crons stay `disabled_manually`; no bundle is deployed by merging. Production go-live (deliberate, manual — see `databricks/README.md`):

1. Provision the **prod listmonk** instance; repoint `dsci/DSCI_LISTMONK_BASE_URL` + sender creds (currently the **demo** instance).
2. Import real subscribers to the info/trigger lists.
3. `databricks bundle deploy -p DEFAULT` (obsv schedule active; fcast trigger-only). Confirm `dry_run=False`, `test_email=False`.
4. **Wire the upstream trigger** in `ds-storms-pipeline` (`nhc_pipeline` → cub `fcast_monitor` via `run_job_task`, against the **prod** job id) — tracked in OCHA-DAP/ds-storms-pipeline#33. See ADR-0002.
5. Leave the GHA monitor workflows disabled (manual fallback).

## Follow-ups (not in this PR)

- `ds-storms-pipeline` upstream `run_job_task` — **OCHA-DAP/ds-storms-pipeline#33** (separate repo; needs the prod cub job id → go-live).
- Startup-time optimization if needed (dep trim / serverless / baked image — see README).
- Pre-existing `FORCE_ALERT` dummy-map-plot `max()` bug (blocks forcing the send path for testing).

