### PR TITLE
Improve email-send observability (unbuffered output + per-send audit log)

### DIFF
--- a/databricks/run_monitor_job.py
+++ b/databricks/run_monitor_job.py
@@ -106,6 +106,11 @@ env = dict(os.environ)
 env["PYTHONPATH"] = LOCAL_ROOT + os.pathsep + env.get("PYTHONPATH", "")
 # matplotlib needs a writable config/cache dir (and must not land on wsfs).
 env["MPLCONFIGDIR"] = "/tmp/mplconfig"
+# Unbuffered stdout/stderr: the child's stdout is block-buffered when piped (not
+# a TTY), so print() output (e.g. the per-email "sending …" lines) can be
+# dropped or reordered relative to logging in the captured task output. Force
+# line-buffering so every send/skip line is reliably visible in the run logs.
+env["PYTHONUNBUFFERED"] = "1"
 
 cmd = [sys.executable, os.path.join(LOCAL_ROOT, _MONITOR_SCRIPTS[MONITOR])]
 

--- a/src/email/listmonk_emails.py
+++ b/src/email/listmonk_emails.py
@@ -146,13 +146,20 @@ def _send_campaign(
     client = ListmonkClient.from_env()
     if with_images:
         body = _upload_and_swap(client, body, monitor_id)
+    list_id = _resolve_list_id(client, list_type)
     cid = client.create_campaign(
         name=_campaign_name(kind, monitor_id),
         subject=subject,
         body=body,
-        list_ids=[_resolve_list_id(client, list_type)],
+        list_ids=[list_id],
         template_id=_resolve_template_id(),
     )
+    # Recipient count from the send manifest (accounts for opt-in/status), so the
+    # log records who the send actually reaches — not just that it fired.
+    try:
+        n_recipients = len(client.build_send_manifest(cid).recipients)
+    except Exception:  # noqa: BLE001 - never let logging break the send
+        n_recipients = "?"
     # Confirmation mode: by default ocha_relay's safe-send prompts the caller to
     # type the campaign name before sending (good for local/manual runs). A
     # headless run has no stdin and would hit EOFError on that prompt, so the
@@ -162,7 +169,10 @@ def _send_campaign(
         "LISTMONK_SKIP_CONFIRMATION", default=False
     )
     client.send_campaign(cid, skip_confirmation=skip_confirmation)
-    logger.info(f"Sent listmonk {kind} campaign {cid} for {monitor_id}")
+    logger.info(
+        f"Sent listmonk {kind} campaign {cid} for {monitor_id} "
+        f"→ list {list_id} ({n_recipients} recipients)"
+    )
 
 
 def send_info_email(monitor_id: str, fcast_obsv: str) -> None:


### PR DESCRIPTION
Adds a richer per-send audit line and unbuffered subprocess output.

**Context / correction:** while verifying the FORCE_ALERT path I thought the run logged only 1 of 3 sends — but that was the **locally-streamed `bundle run` output being truncated**, not a real gap. The full driver log (`databricks jobs get-run-output`) showed all three sends in order the whole time. So this PR is an **observability enrichment**, not a bug fix for dropped logs.

**Changes:**
- `_send_campaign` now logs the **target list id + recipient count** (from the send manifest, which accounts for opt-in/status): `Sent listmonk {kind} campaign {cid} → list {id} (N recipients)`. Count failures never block the send. This is the real value — each send records *who it reached*, not just that it fired.
- Wrapper sets `PYTHONUNBUFFERED=1` — defensive hygiene so the child's stdout streams complete and in order to whatever captures it (does not, on its own, fix the truncated local stream; the authoritative log is `get-run-output`).

**Verified** on a dev FORCE_ALERT run — all three sends logged with the new line:
`readiness 896 → list 108 (1 recipients)`, `action 897 …`, `info 898 …`.
